### PR TITLE
Add new API stk::SleepUntil(Ticks timestamp): to sleep precisely till the specified timestamp

### DIFF
--- a/build/example/blinky_mc/example.cpp
+++ b/build/example/blinky_mc/example.cpp
@@ -79,7 +79,7 @@ class CtrlTask : public stk::Task<TASK_STACK_SIZE, _AccessMode>
 private:
     void Run()
     {
-        int64_t task_start = stk::GetTimeNowMsec();
+        int64_t task_start = stk::GetTimeNowMs();
 
         while (true)
         {
@@ -94,7 +94,7 @@ private:
 
             // sleep 1s and delegate work to another task switching another LED, hw thread could have
             // some latency, thus account for it
-            int32_t sleep = 1000 + (int32_t)(task_start - stk::GetTimeNowMsec());
+            int32_t sleep = 1000 + (int32_t)(task_start - stk::GetTimeNowMs());
             if (sleep > 0)
                 stk::Sleep(sleep);
 
@@ -111,7 +111,7 @@ private:
                 break;
             }
 
-            task_start = stk::GetTimeNowMsec();
+            task_start = stk::GetTimeNowMs();
         }
     }
 };

--- a/build/example/hrt/example.cpp
+++ b/build/example/hrt/example.cpp
@@ -159,7 +159,7 @@ void RunExample()
     static PlatformEventHandler event_overrider;
     kernel.GetPlatform()->SetEventOverrider(&event_overrider);
 
-#define MSEC(MS) GetTicksFromMsec(MS, PERIODICITY_DEFAULT)
+#define MSEC(MS) GetTicksFromMs(MS, PERIODICITY_DEFAULT)
 
     //                    periodicity  deadline   start delay
     kernel.AddTask(&ctrl, MSEC(200),   MSEC(100), MSEC(0));

--- a/build/example/project/eclipse/x86/blinky_c-mingw32/.project
+++ b/build/example/project/eclipse/x86/blinky_c-mingw32/.project
@@ -121,6 +121,11 @@
 			<locationURI>virtual:/virtual</locationURI>
 		</link>
 		<link>
+			<name>deps/stk/include/time</name>
+			<type>2</type>
+			<locationURI>virtual:/virtual</locationURI>
+		</link>
+		<link>
 			<name>deps/stk/interop/c</name>
 			<type>2</type>
 			<locationURI>virtual:/virtual</locationURI>
@@ -219,6 +224,26 @@
 			<name>deps/stk/include/sync/stk_sync_semaphore.h</name>
 			<type>1</type>
 			<locationURI>PARENT-6-PROJECT_LOC/stk/include/sync/stk_sync_semaphore.h</locationURI>
+		</link>
+		<link>
+			<name>deps/stk/include/time/README.md</name>
+			<type>1</type>
+			<locationURI>PARENT-6-PROJECT_LOC/stk/include/time/README.md</locationURI>
+		</link>
+		<link>
+			<name>deps/stk/include/time/stk_time.h</name>
+			<type>1</type>
+			<locationURI>PARENT-6-PROJECT_LOC/stk/include/time/stk_time.h</locationURI>
+		</link>
+		<link>
+			<name>deps/stk/include/time/stk_time_timer.h</name>
+			<type>1</type>
+			<locationURI>PARENT-6-PROJECT_LOC/stk/include/time/stk_time_timer.h</locationURI>
+		</link>
+		<link>
+			<name>deps/stk/include/time/stk_time_util.h</name>
+			<type>1</type>
+			<locationURI>PARENT-6-PROJECT_LOC/stk/include/time/stk_time_util.h</locationURI>
 		</link>
 		<link>
 			<name>deps/stk/interop/c/include</name>

--- a/build/example/secure_task/example.cpp
+++ b/build/example/secure_task/example.cpp
@@ -79,7 +79,7 @@ class CtrlTask : public stk::Task<256, _AccessMode>
 private:
     void Run()
     {
-        int64_t task_start = stk::GetTimeNowMsec();
+        int64_t task_start = stk::GetTimeNowMs();
 
         while (true)
         {
@@ -94,7 +94,7 @@ private:
 
             // sleep 1s and delegate work to another task switching another LED, hw thread could have
             // some latency, thus account for it
-            int32_t sleep = 1000 + (int32_t)(task_start - stk::GetTimeNowMsec());
+            int32_t sleep = 1000 + (int32_t)(task_start - stk::GetTimeNowMs());
             if (sleep > 0)
                 stk::Sleep(sleep);
 
@@ -111,7 +111,7 @@ private:
                 break;
             }
 
-            task_start = stk::GetTimeNowMsec();
+            task_start = stk::GetTimeNowMs();
         }
     }
 };

--- a/build/example/sync/example.cpp
+++ b/build/example/sync/example.cpp
@@ -117,7 +117,7 @@ class CtrlTask : public stk::Task<TASK_STACK_SIZE, _AccessMode>
 private:
     void Run()
     {
-        int64_t task_start = stk::GetTimeNowMsec();
+        int64_t task_start = stk::GetTimeNowMs();
 
     #if !STK_EXAMPLE_USE_PIPE
         g_EventReady.Set();
@@ -134,13 +134,13 @@ private:
 
             // sleep 1s and delegate work to another task switching another LED, hw thread could have
             // some latency, thus account for it
-            int32_t sleep = 250 + (int32_t)(task_start - stk::GetTimeNowMsec());
+            int32_t sleep = 250 + (int32_t)(task_start - stk::GetTimeNowMs());
             if (sleep > 0)
                 stk::Sleep(sleep);
 
             led_sw = !led_sw;
 
-            task_start = stk::GetTimeNowMsec();
+            task_start = stk::GetTimeNowMs();
 
         #if STK_EXAMPLE_USE_PIPE
             if (!g_CtrlSignalPipe.Write(led_sw ? LED_ON : LED_OFF))

--- a/build/example/timer/example.cpp
+++ b/build/example/timer/example.cpp
@@ -74,8 +74,8 @@ void RunExample()
 
     g_Kernel.Initialize();
     g_Timers.Initialize(&g_Kernel, stk::ACCESS_PRIVILEGED);
-    g_Timers.Start(g_LedTimer, 0, stk::GetTicksFromMsec(1000)); // periodic timer, triggered every 1s
-    g_Timers.Start(g_ShutdownTimer, stk::GetTicksFromMsec(20000), 0); // one-shot timer, triggered once in 20s
+    g_Timers.Start(g_LedTimer, 0, stk::GetTicksFromMs(1000)); // periodic timer, triggered every 1s
+    g_Timers.Start(g_ShutdownTimer, stk::GetTicksFromMs(20000), 0); // one-shot timer, triggered once in 20s
     g_Kernel.Start();
 
     for (;;) {}

--- a/interop/c/include/stk_c.h
+++ b/interop/c/include/stk_c.h
@@ -386,9 +386,26 @@ static inline int64_t stk_ticks_from_ms_r(int64_t msec, int32_t resolution)
 int64_t stk_time_now_ms(void);
 
 /*! \brief     Busy-wait delay (other tasks continue to run).
+    \param[in] ticks: Ticks to delay.
+*/
+void stk_delay(uint32_t ticks);
+
+/*! \brief     Busy-wait delay (other tasks continue to run).
     \param[in] ms: Milliseconds to delay.
 */
 void stk_delay_ms(uint32_t ms);
+
+/*! \brief     Put current task to sleep (non-HRT kernels only).
+    \param[in] ms: Ticks to sleep.
+    \note      Unlike stk_delay_ms(), this function does not spin and allows the kernel to
+               idle the CPU. When \a KERNEL_TICKLESS is active and all tasks are sleeping,
+               the SysTick is suppressed and the CPU enters a low-power WFI state until the
+               nearest wake-up deadline.
+    \note      Unsupported in \a KERNEL_HRT mode; in HRT mode tasks sleep automatically
+               according to their periodicity and workload, use stk_yield instead.
+    \see       stk_sleep_ms, stk_sleep_until, stk_ticks
+*/
+void stk_sleep(uint32_t ticks);
 
 /*! \brief     Put current task to sleep (non-HRT kernels only).
     \param[in] ms: Milliseconds to sleep.
@@ -397,9 +414,22 @@ void stk_delay_ms(uint32_t ms);
                the SysTick is suppressed and the CPU enters a low-power WFI state until the
                nearest wake-up deadline.
     \note      Unsupported in \a KERNEL_HRT mode; in HRT mode tasks sleep automatically
-               according to their periodicity and workload.
+               according to their periodicity and workload, use stk_yield instead.
+    \see       stk_sleep, stk_sleep_until, stk_ticks
 */
 void stk_sleep_ms(uint32_t ms);
+
+/*! \brief     Put current task to sleep (non-HRT kernels only).
+    \param[in] ts: Absolute time, a deadline for a sleep period.
+    \note      Unlike stk_delay_ms(), this function does not spin and allows the kernel to
+               idle the CPU. When \a KERNEL_TICKLESS is active and all tasks are sleeping,
+               the SysTick is suppressed and the CPU enters a low-power WFI state until the
+               nearest wake-up deadline.
+    \note      Unsupported in \a KERNEL_HRT mode; in HRT mode tasks sleep automatically
+               according to their periodicity and workload, use stk_yield instead.
+    \see       stk_sleep, stk_sleep_ms, stk_ticks
+*/
+void stk_sleep_until(int64_t ts);
 
 /*! \brief     Voluntarily give up CPU to another ready task (cooperative yield).
 */

--- a/interop/c/src/stk_c.cpp
+++ b/interop/c/src/stk_c.cpp
@@ -320,14 +320,17 @@ void stk_task_destroy(stk_task_t *task)
 // ---------------------------------------------------------------------------
 // Kernel services (available inside tasks)
 // ---------------------------------------------------------------------------
-stk_tid_t stk_tid(void)             { return stk::GetTid(); }
-int64_t   stk_ticks(void)           { return stk::GetTicks(); }
-int32_t   stk_tick_resolution(void) { return stk::GetTickResolution(); }
-int64_t   stk_time_now_ms(void)     { return stk::GetTimeNowMs(); }
-int64_t   stk_ticks_from_ms(int64_t msec) { return stk_ticks_from_ms_r(msec, stk_tick_resolution()); }
-void      stk_delay_ms(uint32_t ms) { stk::Delay(ms); }
-void      stk_sleep_ms(uint32_t ms) { stk::Sleep(ms); }
-void      stk_yield(void)           { stk::Yield(); }
+stk_tid_t stk_tid(void)               { return stk::GetTid(); }
+int64_t   stk_ticks(void)             { return stk::GetTicks(); }
+int32_t   stk_tick_resolution(void)   { return stk::GetTickResolution(); }
+int64_t   stk_time_now_ms(void)       { return stk::GetTimeNowMs(); }
+int64_t   stk_ticks_from_ms(int64_t msec) { return stk_ticks_from_ms_r(msec, stk::GetTickResolution()); }
+void      stk_delay(uint32_t ticks)   { stk::Delay(ticks); }
+void      stk_sleep(uint32_t ticks)   { stk::Sleep(ticks); }
+void      stk_delay_ms(uint32_t ms)   { stk::DelayMs(ms); }
+void      stk_sleep_ms(uint32_t ms)   { stk::SleepMs(ms); }
+void      stk_sleep_until(int64_t ts) { stk::SleepUntil(ts); }
+void      stk_yield(void)             { stk::Yield(); }
 
 // ---------------------------------------------------------------------------
 // Thread-Local Storage (TLS) API

--- a/interop/c/src/stk_c.cpp
+++ b/interop/c/src/stk_c.cpp
@@ -323,7 +323,7 @@ void stk_task_destroy(stk_task_t *task)
 stk_tid_t stk_tid(void)             { return stk::GetTid(); }
 int64_t   stk_ticks(void)           { return stk::GetTicks(); }
 int32_t   stk_tick_resolution(void) { return stk::GetTickResolution(); }
-int64_t   stk_time_now_ms(void)     { return stk::GetTimeNowMsec(); }
+int64_t   stk_time_now_ms(void)     { return stk::GetTimeNowMs(); }
 int64_t   stk_ticks_from_ms(int64_t msec) { return stk_ticks_from_ms_r(msec, stk_tick_resolution()); }
 void      stk_delay_ms(uint32_t ms) { stk::Delay(ms); }
 void      stk_sleep_ms(uint32_t ms) { stk::Sleep(ms); }

--- a/stk/include/arch/arm/cortex-m/stk_arch_arm-cortex-m.h
+++ b/stk/include/arch/arm/cortex-m/stk_arch_arm-cortex-m.h
@@ -37,6 +37,7 @@ public:
     uint32_t GetTickResolution() const;
     void SwitchToNext();
     void Sleep(Timeout ticks);
+    void SleepUntil(Ticks timestamp);
     IWaitObject *Wait(ISyncObject *sync_obj, IMutex *mutex, Timeout timeout);
     void ProcessTick();
     void ProcessHardFault();

--- a/stk/include/arch/risc-v/stk_arch_risc-v.h
+++ b/stk/include/arch/risc-v/stk_arch_risc-v.h
@@ -49,6 +49,7 @@ public:
     uint32_t GetTickResolution() const;
     void SwitchToNext();
     void Sleep(Timeout ticks);
+    void SleepUntil(Ticks timestamp);
     IWaitObject *Wait(ISyncObject *sync_obj, IMutex *mutex, Timeout timeout);
     void ProcessTick();
     void ProcessHardFault();

--- a/stk/include/arch/x86/win32/stk_arch_x86-win32.h
+++ b/stk/include/arch/x86/win32/stk_arch_x86-win32.h
@@ -38,6 +38,7 @@ public:
     uint32_t GetTickResolution() const;
     void SwitchToNext();
     void Sleep(Timeout ticks);
+    void SleepUntil(Ticks timestamp);
     IWaitObject *Wait(ISyncObject *sync_obj, IMutex *mutex, Timeout timeout);
     void ProcessTick();
     void ProcessHardFault();

--- a/stk/include/stk.h
+++ b/stk/include/stk.h
@@ -23,8 +23,8 @@
 
     Include this single header in user application code. It transitively pulls in:
      - stk_helper.h             — Task, TaskW, StackMemoryWrapper; and free-function helpers:
-                                   GetTid, GetTicks, GetTickResolution, GetTicksFromMsec,
-                                   GetMsecFromTicks, GetTimeNowMsec, Delay, Sleep, Yield.
+                                  GetTid, GetTicks, GetTickResolution, GetTicksFromMsec,
+                                  GetMsecFromTicks, GetTimeNowMsec, Delay, Sleep, SleepUntil, Yield.
      - stk_strategy_rrobin.h    — SwitchStrategyRoundRobin.
      - stk_strategy_swrrobin.h  — SwitchStrategySmoothWeightedRoundRobin.
      - stk_strategy_monotonic.h — SwitchStrategyMonotonic (SRT rate-monotonic).
@@ -127,7 +127,7 @@ protected:
         {
             STATE_NONE           = 0,        //!< No pending state flags.
             STATE_REMOVE_PENDING = (1 << 0), //!< Task returned from its Run function; slot will be freed on the next tick (KERNEL_DYNAMIC only).
-            STATE_SLEEP_PENDING  = (1 << 1)  //!< Task called Sleep/Yield; strategy's OnTaskSleep() will be invoked on the next tick (sleep-aware strategies only).
+            STATE_SLEEP_PENDING  = (1 << 1)  //!< Task called Sleep/SleepUntil/Yield; strategy's OnTaskSleep() will be invoked on the next tick (sleep-aware strategies only).
         };
 
     public:
@@ -660,6 +660,26 @@ protected:
             if (!IsHrtMode())
             {
                 m_platform->Sleep(ticks);
+            }
+            else
+            {
+                // sleeping is not supported in HRT mode, task will sleep according to its periodicity and workload
+                STK_ASSERT(false);
+            }
+        }
+
+        /*! \brief     Yield the CPU till \a timestamp, allowing the scheduler to run other tasks.
+            \param[in] timestamp: Absolute time, a deadline for a sleep period.
+            \warning   ISR-unsafe. Asserts (never returns) in KERNEL_HRT mode — HRT tasks sleep
+                       automatically according to their periodicity, not via explicit SleepUntil() calls.
+        */
+        __stk_attr_noinline void SleepUntil(Ticks timestamp)
+        {
+            STK_ASSERT(!hw::IsInsideISR());
+
+            if (!IsHrtMode())
+            {
+                m_platform->SleepUntil(timestamp);
             }
             else
             {
@@ -1340,6 +1360,33 @@ protected:
 
             if (IsHrtMode())
                 task->HrtOnWorkCompleted();
+
+            task->ScheduleSleep(ticks);
+        }
+
+        // note: we do not spin long here, kernel will switch this task out from scheduling on the next tick
+        while (task->IsSleeping())
+        {
+            __stk_relax_cpu();
+        }
+    }
+
+    void OnTaskSleepUntil(Word caller_SP, Ticks timestamp)
+    {
+        STK_ASSERT(!IsHrtMode());
+
+        KernelTask *task = FindTaskBySP(caller_SP);
+        STK_ASSERT(task != nullptr);
+
+        // make change to HRT state and sleep time atomic
+        {
+            hw::CriticalSection::ScopedLock cs_;
+
+            Ticks ticks = timestamp - m_service.m_ticks;
+
+            // if provided timestamp expired, just ignore any sleep for this task
+            if (ticks <= 0)
+                return;
 
             task->ScheduleSleep(ticks);
         }

--- a/stk/include/stk.h
+++ b/stk/include/stk.h
@@ -608,9 +608,14 @@ protected:
     public:
         /*! \brief  Get the TId of the calling task.
             \return TId via platform->GetTid(), which resolves by stack pointer.
-            \warning ISR-unsafe. Asserted in the helper-layer wrapper stk::GetTid().
+            \warning ISR-unsafe.
         */
-        TId GetTid() const { return m_platform->GetTid(); }
+        TId GetTid() const
+        {
+            STK_ASSERT(!hw::IsInsideISR());
+
+            return m_platform->GetTid();
+        }
 
         /*! \brief  Get the current tick count since kernel start.
             \return Atomically-read 64-bit tick counter (via hw::ReadVolatile64).
@@ -624,32 +629,37 @@ protected:
         */
         int32_t GetTickResolution() const  { return m_platform->GetTickResolution(); }
 
-        /*! \brief     Busy-wait until \a msec milliseconds have elapsed.
-            \param[in] msec: Delay in milliseconds.
+        /*! \brief     Busy-wait until \a ticks have elapsed.
+            \param[in] ticks: Delay time in ticks.
             \note      Spins calling __stk_relax_cpu() in a loop. Does not yield the CPU.
             \warning   ISR-unsafe. In HRT mode, long busy-waits will cause deadline misses.
         */
-        __stk_attr_noinline void Delay(Timeout msec)
+        __stk_attr_noinline void Delay(Timeout ticks)
         {
-            Ticks deadline = GetTicks() + GetTicksFromMsec(msec, GetTickResolution());
-            while (GetTicks() < deadline)
+            STK_ASSERT(!hw::IsInsideISR());
+
+            Ticks now = GetTicks();
+            const Ticks deadline = now + ticks;
+            STK_ASSERT(deadline >= now);
+
+            for (; now < deadline; now = GetTicks())
             {
                 __stk_relax_cpu();
             }
         }
 
-        /*! \brief     Yield the CPU for \a msec milliseconds, allowing the scheduler to run other tasks.
-            \param[in] msec: Sleep time in milliseconds.
-            \note      Converts msec to ticks and calls platform->Sleep() which schedules the calling
-                       task to sleep and spins until the kernel switches it back in.
+        /*! \brief     Yield the CPU for \a ticks, allowing the scheduler to run other tasks.
+            \param[in] ticks: Sleep time in ticks.
             \warning   ISR-unsafe. Asserts (never returns) in KERNEL_HRT mode — HRT tasks sleep
                        automatically according to their periodicity, not via explicit Sleep() calls.
         */
-        __stk_attr_noinline void Sleep(Timeout msec)
+        __stk_attr_noinline void Sleep(Timeout ticks)
         {
+            STK_ASSERT(!hw::IsInsideISR());
+
             if (!IsHrtMode())
             {
-                m_platform->Sleep((Timeout)GetTicksFromMsec(msec, GetTickResolution()));
+                m_platform->Sleep(ticks);
             }
             else
             {
@@ -663,7 +673,12 @@ protected:
                    another task on the very next tick. The calling task is rescheduled promptly.
             \warning ISR-unsafe.
         */
-        void SwitchToNext() { m_platform->SwitchToNext(); }
+        void SwitchToNext()
+        {
+            STK_ASSERT(!hw::IsInsideISR());
+
+            m_platform->SwitchToNext();
+        }
 
         /*! \brief     Block the calling task until a synchronization object signals or the timeout expires.
             \param[in] sobj: Sync object to wait on. Must belong to this kernel's m_sync_list or be unregistered.

--- a/stk/include/stk_common.h
+++ b/stk/include/stk_common.h
@@ -625,6 +625,12 @@ public:
         */
         virtual void OnTaskSleep(Word caller_SP, Timeout ticks) = 0;
 
+        /*! \brief      Called by Thread process (via IKernelService::SleepUntil) for exclusion of the calling process from scheduling (sleeping).
+            \param[in]  caller_SP: Value of Stack Pointer (SP) register (for locating the calling process inside the kernel).
+            \param[in]  timestamp: Absolute timestamp (ticks).
+        */
+        virtual void OnTaskSleepUntil(Word caller_SP, Ticks timestamp) = 0;
+
         /*! \brief      Called from the Thread process when task finished (its Run function exited by return).
             \param[out] stack: Stack of the exited task.
         */
@@ -707,6 +713,14 @@ public:
         \param[in] ticks: Time to sleep (ticks).
     */
     virtual void Sleep(Timeout ticks) = 0;
+
+    /*! \brief     Put calling process into a sleep state until the specified timestamp.
+        \note      Unlike Delay this function does not waste CPU cycles and allows kernel to put CPU into a low-power state.
+        \note      Unsupported in HRT mode (see stk::KERNEL_HRT); in HRT mode tasks sleep automatically according to their periodicity and workload.
+        \param[in] timestamp: Absolute timestamp (ticks).
+        \warning   ISR-unsafe. Calling from an ISR context is not permitted and will trigger an assertion.
+    */
+    virtual void SleepUntil(Ticks timestamp) = 0;
 
     /*! \brief     Process one tick.
         \note      Normally system tick is processed by the platform driver implementation.
@@ -920,7 +934,7 @@ public:
 
     /*! \brief     Get thread Id of the currently running task.
         \return    Thread Id.
-        \warning   ISR-unsafe. Calling from an ISR context will trigger an assertion.
+        \warning   ISR-unsafe. Calling from an ISR context is not permitted and will trigger an assertion.
     */
     virtual TId GetTid() const = 0;
 
@@ -941,7 +955,7 @@ public:
         \note      Unlike Sleep this function delays code execution by spinning in a loop until deadline expiry.
         \note      Use with care in HRT mode to avoid missed deadline (see stk::KERNEL_HRT, ITask::OnDeadlineMissed).
         \param[in] ticks: Delay time (ticks).
-        \warning   ISR-unsafe.
+        \warning   ISR-unsafe. Calling from an ISR context is not permitted and will trigger an assertion.
         \see       Delay
     */
     virtual void Delay(Timeout ticks) = 0;
@@ -950,9 +964,17 @@ public:
         \note      Unlike Delay this function does not waste CPU cycles and allows kernel to put CPU into a low-power state.
         \note      Unsupported in HRT mode (see stk::KERNEL_HRT); in HRT mode tasks sleep automatically according to their periodicity and workload.
         \param[in] ticks: Sleep time (ticks).
-        \warning   ISR-unsafe.
+        \warning   ISR-unsafe. Calling from an ISR context is not permitted and will trigger an assertion.
     */
     virtual void Sleep(Timeout ticks) = 0;
+
+    /*! \brief     Put calling process into a sleep state until the specified timestamp.
+        \note      Unlike Delay this function does not waste CPU cycles and allows kernel to put CPU into a low-power state.
+        \note      Unsupported in HRT mode (see stk::KERNEL_HRT); in HRT mode tasks sleep automatically according to their periodicity and workload.
+        \param[in] timestamp: Absolute timestamp (ticks).
+        \warning   ISR-unsafe. Calling from an ISR context is not permitted and will trigger an assertion.
+    */
+    virtual void SleepUntil(Ticks timestamp) = 0;
 
     /*! \brief     Notify scheduler to switch to the next task (yield).
         \note      A cooperation mechanism in HRT mode (see stk::KERNEL_HRT).

--- a/stk/include/stk_common.h
+++ b/stk/include/stk_common.h
@@ -662,10 +662,6 @@ public:
             \return True if event is handled otherwise False to let driver handle it.
         */
         virtual bool OnHardFault() = 0;
-
-    private:
-        ~IEventOverrider()
-        {}
     };
 
     /*! \brief     Initialize scheduler's context.
@@ -944,26 +940,23 @@ public:
     /*! \brief     Delay calling process.
         \note      Unlike Sleep this function delays code execution by spinning in a loop until deadline expiry.
         \note      Use with care in HRT mode to avoid missed deadline (see stk::KERNEL_HRT, ITask::OnDeadlineMissed).
-        \param[in] msec: Delay time (milliseconds).
+        \param[in] ticks: Delay time (ticks).
         \warning   ISR-unsafe.
+        \see       Delay
     */
-    virtual void Delay(Timeout msec) = 0;
+    virtual void Delay(Timeout ticks) = 0;
 
     /*! \brief     Put calling process into a sleep state.
         \note      Unlike Delay this function does not waste CPU cycles and allows kernel to put CPU into a low-power state.
         \note      Unsupported in HRT mode (see stk::KERNEL_HRT); in HRT mode tasks sleep automatically according to their periodicity and workload.
-        \param[in] msec: Sleep time (milliseconds).
+        \param[in] ticks: Sleep time (ticks).
         \warning   ISR-unsafe.
-        \warning   Caller must lock the hw::CriticalSection with hw::CriticalSection::Enter() before calling this function.
-                   Kernel will exit the hw::CriticalSection with hw::CriticalSection::Exit() upon return from this function.
     */
-    virtual void Sleep(Timeout msec) = 0;
+    virtual void Sleep(Timeout ticks) = 0;
 
     /*! \brief     Notify scheduler to switch to the next task (yield).
         \note      A cooperation mechanism in HRT mode (see stk::KERNEL_HRT).
         \warning   ISR-unsafe.
-        \warning   Caller must lock the hw::CriticalSection with hw::CriticalSection::Enter() before calling this function.
-                   Kernel will exit the hw::CriticalSection with hw::CriticalSection::Exit() upon return from this function.
     */
     virtual void SwitchToNext() = 0;
 

--- a/stk/include/stk_helper.h
+++ b/stk/include/stk_helper.h
@@ -289,28 +289,6 @@ static inline int64_t GetTimeNowMs()
         return (service->GetTicks() * resolution) / 1000;
 }
 
-/*! \brief     Delay calling process by busy-waiting until the deadline expires.
-    \note      Unlike Sleep this function delays code execution by spinning in a loop until deadline expiry.
-    \note      Use with care in HRT mode to avoid missed deadline (see stk::KERNEL_HRT, ITask::OnDeadlineMissed).
-    \param[in] ticks: Delay time (ticks).
-    \warning   ISR-unsafe. Calling from an ISR context is not permitted and will trigger an assertion.
-*/
-__stk_forceinline void Delay(uint32_t ticks)
-{
-    IKernelService::GetInstance()->Delay(ticks);
-}
-
-/*! \brief     Delay calling process by busy-waiting until the deadline expires.
-    \note      Unlike Sleep this function delays code execution by spinning in a loop until deadline expiry.
-    \note      Use with care in HRT mode to avoid missed deadline (see stk::KERNEL_HRT, ITask::OnDeadlineMissed).
-    \param[in] ms: Delay time (milliseconds).
-    \warning   ISR-unsafe. Calling from an ISR context is not permitted and will trigger an assertion.
-*/
-static inline void DelayMs(uint32_t ms)
-{
-    Delay(static_cast<Timeout>(GetTicksFromMs(ms)));
-}
-
 /*! \brief     Put calling process into a sleep state.
     \note      Unlike Delay this function does not waste CPU cycles and allows kernel to put CPU into a low-power state.
     \note      Unsupported in HRT mode (see stk::KERNEL_HRT); in HRT mode tasks sleep automatically according to their periodicity and workload.
@@ -335,6 +313,17 @@ static inline void SleepMs(uint32_t ms)
     Sleep(static_cast<Timeout>(GetTicksFromMs(ms)));
 }
 
+/*! \brief     Put calling process into a sleep state until the specified timestamp.
+    \note      Unlike Delay this function does not waste CPU cycles and allows kernel to put CPU into a low-power state.
+    \note      Unsupported in HRT mode (see stk::KERNEL_HRT); in HRT mode tasks sleep automatically according to their periodicity and workload.
+    \param[in] timestamp: Absolute timestamp (ticks).
+    \warning   ISR-unsafe. Calling from an ISR context is not permitted and will trigger an assertion.
+*/
+__stk_forceinline void SleepUntil(Ticks timestamp)
+{
+    IKernelService::GetInstance()->SleepUntil(timestamp);
+}
+
 /*! \brief     Notify scheduler to switch to the next runnable task.
     \note      A cooperative scheduling mechanism. In HRT mode acts as a cooperation point (see stk::KERNEL_HRT).
     \warning   ISR-unsafe. Calling from an ISR context is not permitted and will trigger an assertion.
@@ -342,6 +331,28 @@ static inline void SleepMs(uint32_t ms)
 __stk_forceinline void Yield()
 {
     IKernelService::GetInstance()->SwitchToNext();
+}
+
+/*! \brief     Delay calling process by busy-waiting until the deadline expires.
+    \note      Unlike Sleep this function delays code execution by spinning in a loop until deadline expiry.
+    \note      Use with care in HRT mode to avoid missed deadline (see stk::KERNEL_HRT, ITask::OnDeadlineMissed).
+    \param[in] ticks: Delay time (ticks).
+    \warning   ISR-unsafe. Calling from an ISR context is not permitted and will trigger an assertion.
+*/
+__stk_forceinline void Delay(uint32_t ticks)
+{
+    IKernelService::GetInstance()->Delay(ticks);
+}
+
+/*! \brief     Delay calling process by busy-waiting until the deadline expires.
+    \note      Unlike Sleep this function delays code execution by spinning in a loop until deadline expiry.
+    \note      Use with care in HRT mode to avoid missed deadline (see stk::KERNEL_HRT, ITask::OnDeadlineMissed).
+    \param[in] ms: Delay time (milliseconds).
+    \warning   ISR-unsafe. Calling from an ISR context is not permitted and will trigger an assertion.
+*/
+static inline void DelayMs(uint32_t ms)
+{
+    Delay(static_cast<Timeout>(GetTicksFromMs(ms)));
 }
 
 } // namespace stk

--- a/stk/include/stk_helper.h
+++ b/stk/include/stk_helper.h
@@ -216,8 +216,6 @@ private:
 */
 __stk_forceinline TId GetTid()
 {
-    STK_ASSERT(!hw::IsInsideISR());
-
     return IKernelService::GetInstance()->GetTid();
 }
 
@@ -227,20 +225,20 @@ __stk_forceinline TId GetTid()
     \return    Equivalent time in milliseconds.
     \note      ISR-safe (performs only arithmetic, no kernel calls).
 */
-__stk_forceinline int64_t GetMsecFromTicks(int64_t ticks, int32_t resolution)
+__stk_forceinline int64_t GetMsFromTicks(int64_t ticks, int32_t resolution)
 {
     return (ticks * resolution) / 1000;
 }
 
 /*! \brief     Convert milliseconds to ticks.
-    \param[in] msec: Time in milliseconds to convert.
+    \param[in] ms: Time in milliseconds to convert.
     \param[in] resolution: Microseconds per tick, as returned by IKernelService::GetTickResolution().
     \return    Equivalent tick count.
     \note      ISR-safe (performs only arithmetic, no kernel calls).
 */
-__stk_forceinline Ticks GetTicksFromMsec(int64_t msec, int32_t resolution)
+__stk_forceinline Ticks GetTicksFromMs(int64_t ms, int32_t resolution)
 {
-    return msec * 1000 / resolution;
+    return ms * 1000 / resolution;
 }
 
 /*! \brief     Get number of ticks elapsed since kernel start.
@@ -263,15 +261,15 @@ __stk_forceinline int32_t GetTickResolution()
 }
 
 /*! \brief     Convert milliseconds to ticks using the current kernel tick resolution.
-    \param[in] msec: Time in milliseconds to convert.
+    \param[in] ms: Time in milliseconds to convert.
     \return    Equivalent tick count.
     \note      Convenience overload that queries GetTickResolution() automatically.
-               Use the two-argument form GetTicksFromMsec(msec, resolution) in ISR context.
+               Use the two-argument form GetTicksFromMsec(ms, resolution) in ISR context.
     \warning   ISR-unsafe (internally calls GetTickResolution() which accesses the kernel service).
 */
-__stk_forceinline Ticks GetTicksFromMsec(int64_t msec)
+__stk_forceinline Ticks GetTicksFromMs(int64_t ms)
 {
-    return GetTicksFromMsec(msec, GetTickResolution());
+    return GetTicksFromMs(ms, GetTickResolution());
 }
 
 /*! \brief     Get current time in milliseconds since kernel start.
@@ -280,7 +278,7 @@ __stk_forceinline Ticks GetTicksFromMsec(int64_t msec)
     \note      When the tick resolution is exactly 1000 µs (1 ms, the default PERIODICITY_DEFAULT),
                the tick count is returned directly without multiplication, avoiding a 64-bit multiply.
 */
-__stk_forceinline int64_t GetTimeNowMsec()
+static inline int64_t GetTimeNowMs()
 {
     IKernelService *service = IKernelService::GetInstance();
     int32_t resolution = service->GetTickResolution();
@@ -294,37 +292,55 @@ __stk_forceinline int64_t GetTimeNowMsec()
 /*! \brief     Delay calling process by busy-waiting until the deadline expires.
     \note      Unlike Sleep this function delays code execution by spinning in a loop until deadline expiry.
     \note      Use with care in HRT mode to avoid missed deadline (see stk::KERNEL_HRT, ITask::OnDeadlineMissed).
-    \param[in] msec: Delay time (milliseconds).
-    \warning   ISR-unsafe. Calling from an ISR would spin indefinitely, deadlocking the system.
+    \param[in] ticks: Delay time (ticks).
+    \warning   ISR-unsafe. Calling from an ISR context is not permitted and will trigger an assertion.
 */
-__stk_forceinline void Delay(uint32_t msec)
+__stk_forceinline void Delay(uint32_t ticks)
 {
-    STK_ASSERT(!hw::IsInsideISR());
+    IKernelService::GetInstance()->Delay(ticks);
+}
 
-    IKernelService::GetInstance()->Delay(msec);
+/*! \brief     Delay calling process by busy-waiting until the deadline expires.
+    \note      Unlike Sleep this function delays code execution by spinning in a loop until deadline expiry.
+    \note      Use with care in HRT mode to avoid missed deadline (see stk::KERNEL_HRT, ITask::OnDeadlineMissed).
+    \param[in] ms: Delay time (milliseconds).
+    \warning   ISR-unsafe. Calling from an ISR context is not permitted and will trigger an assertion.
+*/
+static inline void DelayMs(uint32_t ms)
+{
+    Delay(static_cast<Timeout>(GetTicksFromMs(ms)));
 }
 
 /*! \brief     Put calling process into a sleep state.
     \note      Unlike Delay this function does not waste CPU cycles and allows kernel to put CPU into a low-power state.
     \note      Unsupported in HRT mode (see stk::KERNEL_HRT); in HRT mode tasks sleep automatically according to their periodicity and workload.
-    \param[in] msec: Sleep time (milliseconds).
-    \warning   ISR-unsafe. Calling from an ISR would block the scheduler indefinitely, deadlocking the system.
+    \param[in] ticks: Sleep time (ticks).
+    \warning   ISR-unsafe. Calling from an ISR context is not permitted and will trigger an assertion.
 */
-__stk_forceinline void Sleep(uint32_t msec)
+__stk_forceinline void Sleep(uint32_t ticks)
 {
-    STK_ASSERT(!hw::IsInsideISR());
+    IKernelService::GetInstance()->Sleep(ticks);
+}
 
-    IKernelService::GetInstance()->Sleep(msec);
+/*! \brief     Put calling process into a sleep state.
+    \note      Unlike Delay this function does not waste CPU cycles and allows kernel to put CPU into a low-power state.
+    \note      Unsupported in HRT mode (see stk::KERNEL_HRT); in HRT mode tasks sleep automatically according to their periodicity and workload.
+    \note      Converts ms to ticks and calls IKernelService::SleepTicks() which schedules the calling
+               task to sleep and spins until the kernel switches it back in.
+    \param[in] ms: Sleep time (milliseconds).
+    \warning   ISR-unsafe. Calling from an ISR context is not permitted and will trigger an assertion.
+*/
+static inline void SleepMs(uint32_t ms)
+{
+    Sleep(static_cast<Timeout>(GetTicksFromMs(ms)));
 }
 
 /*! \brief     Notify scheduler to switch to the next runnable task.
     \note      A cooperative scheduling mechanism. In HRT mode acts as a cooperation point (see stk::KERNEL_HRT).
-    \warning   ISR-unsafe. Calling from an ISR would block the scheduler indefinitely, deadlocking the system.
+    \warning   ISR-unsafe. Calling from an ISR context is not permitted and will trigger an assertion.
 */
 __stk_forceinline void Yield()
 {
-    STK_ASSERT(!hw::IsInsideISR());
-
     IKernelService::GetInstance()->SwitchToNext();
 }
 

--- a/stk/src/arch/arm/cortex-m/stk_arch_arm-cortex-m.cpp
+++ b/stk/src/arch/arm/cortex-m/stk_arch_arm-cortex-m.cpp
@@ -1682,6 +1682,11 @@ void PlatformArmCortexM::Sleep(Timeout ticks)
     GetContext().m_handler->OnTaskSleep(HW_GetCallerSP(), ticks);
 }
 
+void PlatformArmCortexM::SleepUntil(Ticks timestamp)
+{
+    GetContext().m_handler->OnTaskSleepUntil(HW_GetCallerSP(), timestamp);
+}
+
 IWaitObject *PlatformArmCortexM::Wait(ISyncObject *sync_obj, IMutex *mutex, Timeout timeout)
 {
     return GetContext().m_handler->OnTaskWait(HW_GetCallerSP(), sync_obj, mutex, timeout);

--- a/stk/src/arch/risc-v/stk_arch_risc-v.cpp
+++ b/stk/src/arch/risc-v/stk_arch_risc-v.cpp
@@ -1872,6 +1872,11 @@ void PlatformRiscV::Sleep(Timeout ticks)
     GetContext().m_handler->OnTaskSleep(HW_GetCallerSP(), ticks);
 }
 
+void PlatformRiscV::SleepUntil(Ticks timestamp)
+{
+    GetContext().m_handler->OnTaskSleepUntil(HW_GetCallerSP(), timestamp);
+}
+
 IWaitObject *PlatformRiscV::Wait(ISyncObject *sync_obj, IMutex *mutex, Timeout timeout)
 {
     return GetContext().m_handler->OnTaskWait(HW_GetCallerSP(), sync_obj, mutex, timeout);

--- a/stk/src/arch/x86/win32/stk_arch_x86-win32.cpp
+++ b/stk/src/arch/x86/win32/stk_arch_x86-win32.cpp
@@ -261,6 +261,7 @@ static struct Context : public PlatformContext
     void SwitchContext();
     void SwitchToNext();
     void Sleep(Timeout ticks);
+    void SleepUntil(Ticks timestamp);
     IWaitObject *Wait(ISyncObject *sync_obj, IMutex *mutex, Timeout timeout);
     void Stop();
     Word GetCallerSP() const;
@@ -540,6 +541,11 @@ void Context::Sleep(Timeout ticks)
     m_handler->OnTaskSleep(GetCallerSP(), ticks);
 }
 
+void Context::SleepUntil(Ticks timestamp)
+{
+    m_handler->OnTaskSleepUntil(GetCallerSP(), timestamp);
+}
+
 IWaitObject *Context::Wait(ISyncObject *sync_obj, IMutex *mutex, Timeout timeout)
 {
     return m_handler->OnTaskWait(GetCallerSP(), sync_obj, mutex, timeout);
@@ -616,6 +622,11 @@ void PlatformX86Win32::SwitchToNext()
 void PlatformX86Win32::Sleep(Timeout ticks)
 {
     GetContext().Sleep(ticks);
+}
+
+void PlatformX86Win32::SleepUntil(Ticks timestamp)
+{
+    GetContext().SleepUntil(timestamp);
 }
 
 IWaitObject *PlatformX86Win32::Wait(ISyncObject *sync_obj, IMutex *mutex, Timeout timeout)

--- a/test/chain/stktest_chain.cpp
+++ b/test/chain/stktest_chain.cpp
@@ -61,7 +61,7 @@ template<> void TestTask<ACCESS_PRIVILEGED>::Run()
 {
     uint8_t task_id = m_task_id;
 
-    g_Time[task_id] = stk::GetTimeNowMsec();
+    g_Time[task_id] = stk::GetTimeNowMs();
 
     printf("id=%d time=%d\n", task_id, (int)g_Time[task_id]);
 

--- a/test/condvar/test_condvar.cpp
+++ b/test/condvar/test_condvar.cpp
@@ -190,9 +190,9 @@ private:
             stk::Sleep(_STK_CV_TEST_SHORT_SLEEP);
 
             g_TestMutex.Lock();
-            int64_t start   = GetTimeNowMsec();
+            int64_t start   = GetTimeNowMs();
             bool    woken   = g_TestCond.Wait(g_TestMutex, 50);
-            int64_t elapsed = GetTimeNowMsec() - start;
+            int64_t elapsed = GetTimeNowMs() - start;
             g_TestMutex.Unlock();
 
             // Must return false (timeout), and elapsed must be within the 50-tick window
@@ -456,9 +456,9 @@ private:
         {
             // NO_WAIT must return false immediately with no blocking
             g_TestMutex.Lock();
-            int64_t start   = GetTimeNowMsec();
+            int64_t start   = GetTimeNowMs();
             bool    woken   = g_TestCond.Wait(g_TestMutex, NO_WAIT);
-            int64_t elapsed = GetTimeNowMsec() - start;
+            int64_t elapsed = GetTimeNowMs() - start;
             g_TestMutex.Unlock();
 
             if (!woken && elapsed < _STK_CV_TEST_SHORT_SLEEP)

--- a/test/event/test_event.cpp
+++ b/test/event/test_event.cpp
@@ -226,9 +226,9 @@ private:
             // Task 1: Wait with 50-tick timeout; must expire before task 0 fires Set()
             stk::Sleep(_STK_EVT_TEST_SHORT_SLEEP);
 
-            int64_t start   = GetTimeNowMsec();
+            int64_t start   = GetTimeNowMs();
             bool acquired   = g_TestEvent.Wait(50);
-            int64_t elapsed = GetTimeNowMsec() - start;
+            int64_t elapsed = GetTimeNowMs() - start;
 
             if (!acquired && elapsed >= 45 && elapsed <= 60)
                 ++g_SharedCounter;
@@ -278,9 +278,9 @@ private:
         if (m_task_id == 1)
         {
             // TryWait on a non-signaled event must return false immediately
-            int64_t start   = GetTimeNowMsec();
+            int64_t start   = GetTimeNowMs();
             bool acquired   = g_TestEvent.TryWait();
-            int64_t elapsed = GetTimeNowMsec() - start;
+            int64_t elapsed = GetTimeNowMs() - start;
 
             if (!acquired && elapsed < _STK_EVT_TEST_SHORT_SLEEP)
                 ++g_SharedCounter;
@@ -291,9 +291,9 @@ private:
             // Signal the event, then TryWait must return true and auto-reset it
             g_TestEvent.Set();
 
-            int64_t start   = GetTimeNowMsec();
+            int64_t start   = GetTimeNowMs();
             bool acquired   = g_TestEvent.TryWait();
-            int64_t elapsed = GetTimeNowMsec() - start;
+            int64_t elapsed = GetTimeNowMs() - start;
 
             if (acquired && elapsed < _STK_EVT_TEST_SHORT_SLEEP)
                 ++g_SharedCounter;

--- a/test/eventflags/test_eventflags.cpp
+++ b/test/eventflags/test_eventflags.cpp
@@ -327,9 +327,9 @@ private:
             stk::Sleep(_STK_EF_TEST_SHORT_SLEEP);
 
             // Wait with a 50-tick timeout; must expire before task 0 fires Set()
-            int64_t start   = GetTimeNowMsec();
+            int64_t start   = GetTimeNowMs();
             uint32_t result = g_Flags.Wait(FLAG_A, sync::EventFlags::OPT_WAIT_ANY, 50);
-            int64_t elapsed = GetTimeNowMsec() - start;
+            int64_t elapsed = GetTimeNowMs() - start;
 
             if ((result == sync::EventFlags::ERROR_TIMEOUT) && (elapsed >= 45) && (elapsed <= 60))
                 ++g_SharedCounter;
@@ -381,9 +381,9 @@ private:
         if (m_task_id == 1)
         {
             // TryWait on a non-set flag must return immediately with an error
-            int64_t  start   = GetTimeNowMsec();
+            int64_t  start   = GetTimeNowMs();
             uint32_t result  = g_Flags.TryWait(FLAG_A);
-            int64_t  elapsed = GetTimeNowMsec() - start;
+            int64_t  elapsed = GetTimeNowMs() - start;
 
             if (sync::EventFlags::IsError(result) && (elapsed < _STK_EF_TEST_SHORT_SLEEP))
                 ++g_SharedCounter;
@@ -394,9 +394,9 @@ private:
             // Set FLAG_A then TryWait; must succeed and auto-clear
             g_Flags.Set(FLAG_A);
 
-            int64_t  start   = GetTimeNowMsec();
+            int64_t  start   = GetTimeNowMs();
             uint32_t result  = g_Flags.TryWait(FLAG_A);
-            int64_t  elapsed = GetTimeNowMsec() - start;
+            int64_t  elapsed = GetTimeNowMs() - start;
 
             if (!sync::EventFlags::IsError(result) && (elapsed < _STK_EF_TEST_SHORT_SLEEP))
                 ++g_SharedCounter;

--- a/test/generic/stktest_kernel.cpp
+++ b/test/generic/stktest_kernel.cpp
@@ -846,6 +846,18 @@ TEST(Kernel, HrtSleepNotAllowed)
         CHECK(true);
         g_TestContext.ExpectAssert(false);
     }
+
+    try
+    {
+        g_TestContext.ExpectAssert(true);
+        SleepUntil(GetTicks() + 1);
+        CHECK_TEXT(false, "IKernelService::SleepUntil not allowed in HRT mode");
+    }
+    catch (TestAssertPassed &pass)
+    {
+        CHECK(true);
+        g_TestContext.ExpectAssert(false);
+    }
 }
 
 TEST(Kernel, HrtTaskCompleted)

--- a/test/generic/stktest_kernelservice.cpp
+++ b/test/generic/stktest_kernelservice.cpp
@@ -82,6 +82,25 @@ TEST(KernelService, Delay)
     CHECK_EQUAL(10, (int32_t)g_KernelService->GetTicks());
 }
 
+TEST(KernelService, DelayMs)
+{
+    Kernel<KERNEL_STATIC, 1, SwitchStrategyRR, PlatformTestMock> kernel;
+    TaskMock<ACCESS_USER> task;
+
+    kernel.Initialize(2000); // decrease resolution to 1 tick = 2 ms
+    kernel.AddTask(&task);
+    kernel.Start();
+
+    g_RelaxCpuHandler = DelayRelaxCpu;
+    g_DelayContext.platform = kernel.GetPlatform();
+
+    DelayMs(10);
+
+    g_RelaxCpuHandler = NULL;
+
+    CHECK_EQUAL(5, (int32_t)g_KernelService->GetTicks());
+}
+
 TEST(KernelService, InitStackFailure)
 {
     Kernel<KERNEL_STATIC, 2, SwitchStrategyRR, PlatformTestMock> kernel;
@@ -377,7 +396,7 @@ static void SleepRelaxCpu()
 }
 
 template <class _SwitchStrategy>
-static void TestTaskSleep()
+static void TestTaskSleep(bool until)
 {
     Kernel<KERNEL_STATIC, 2, _SwitchStrategy, PlatformTestMock> kernel;
     TaskMock<ACCESS_USER> task1, task2;
@@ -403,7 +422,14 @@ static void TestTaskSleep()
     g_SleepRelaxCpuContext.task2    = &task2;
 
     // task2 calls Sleep to become idle
-    Sleep(2);
+    if (until)
+    {
+        SleepUntil(GetTicks() + 2);
+    }
+    else
+    {
+        Sleep(2);
+    }
 
     // task2 slept 2 ticks and became active again when became a tail of previously active task1
     CHECK_EQUAL_TEXT(active->SP, (size_t)task2.GetStack(), "expecting task2 after sleep");
@@ -415,17 +441,104 @@ static void TestTaskSleep()
 
 TEST(KernelService, SleepRR)
 {
-    TestTaskSleep<SwitchStrategyRR>();
+    TestTaskSleep<SwitchStrategyRR>(false);
 }
 
 TEST(KernelService, SleepSWRR)
 {
-    TestTaskSleep<SwitchStrategySWRR>();
+    TestTaskSleep<SwitchStrategySWRR>(false);
 }
 
 TEST(KernelService, SleepFP31)
 {
-    TestTaskSleep<SwitchStrategyFP32>();
+    TestTaskSleep<SwitchStrategyFP32>(false);
+}
+
+TEST(KernelService, SleepUntilRR)
+{
+    TestTaskSleep<SwitchStrategyRR>(true);
+}
+
+TEST(KernelService, SleepUntilSWRR)
+{
+    TestTaskSleep<SwitchStrategySWRR>(true);
+}
+
+TEST(KernelService, SleepUntilFP31)
+{
+    TestTaskSleep<SwitchStrategyFP32>(true);
+}
+
+TEST(KernelService, SleepMsRR)
+{
+    Kernel<KERNEL_STATIC, 2, SwitchStrategyRR, PlatformTestMock> kernel;
+    TaskMock<ACCESS_USER> task1, task2;
+    PlatformTestMock *platform = static_cast<PlatformTestMock *>(kernel.GetPlatform());
+    Stack *&active = platform->m_stack_active;
+
+    kernel.Initialize();
+    kernel.AddTask(&task1);
+    kernel.AddTask(&task2);
+    kernel.Start();
+
+    // on start Round-Robin selects the very first task
+    CHECK_EQUAL_TEXT(active->SP, (size_t)task1.GetStack(), "expecting task1");
+
+    // ISR calls OnSysTick (task1 = idle, task2 = active)
+    platform->ProcessTick();
+    CHECK_EQUAL_TEXT(active->SP, (size_t)task2.GetStack(), "expecting task2");
+
+    g_RelaxCpuHandler = SleepRelaxCpu;
+    g_SleepRelaxCpuContext.Clear();
+    g_SleepRelaxCpuContext.platform = platform;
+    g_SleepRelaxCpuContext.task1    = &task1;
+    g_SleepRelaxCpuContext.task2    = &task2;
+
+    // task2 calls Sleep to become idle
+    SleepMs(2);
+
+    // task2 slept 2 ticks and became active again when became a tail of previously active task1
+    CHECK_EQUAL_TEXT(active->SP, (size_t)task2.GetStack(), "expecting task2 after sleep");
+
+    // ISR calls OnSysTick (task1 = active, task2 = idle)
+    platform->ProcessTick();
+    CHECK_EQUAL_TEXT(active->SP, (size_t)task1.GetStack(), "expecting task1 after next tick");
+}
+
+TEST(KernelService, SleepUntilMissDeadline)
+{
+    Kernel<KERNEL_STATIC, 2, SwitchStrategyRR, PlatformTestMock> kernel;
+    TaskMock<ACCESS_USER> task1, task2;
+    PlatformTestMock *platform = static_cast<PlatformTestMock *>(kernel.GetPlatform());
+    Stack *&active = platform->m_stack_active;
+
+    kernel.Initialize();
+    kernel.AddTask(&task1);
+    kernel.AddTask(&task2);
+    kernel.Start();
+
+    // on start Round-Robin selects the very first task
+    CHECK_EQUAL_TEXT(active->SP, (size_t)task1.GetStack(), "expecting task1");
+
+    // ISR calls OnSysTick (task1 = idle, task2 = active)
+    platform->ProcessTick();
+    CHECK_EQUAL_TEXT(active->SP, (size_t)task2.GetStack(), "expecting task2");
+
+    g_RelaxCpuHandler = SleepRelaxCpu;
+    g_SleepRelaxCpuContext.Clear();
+    g_SleepRelaxCpuContext.platform = platform;
+    g_SleepRelaxCpuContext.task1    = &task1;
+    g_SleepRelaxCpuContext.task2    = &task2;
+
+    Ticks now = GetTicks();
+
+    // task2 calls Sleep to become idle
+    SleepUntil(now);
+
+    CHECK_EQUAL(now, GetTicks());
+
+    // task2 is still active as it did not sleep
+    CHECK_EQUAL_TEXT(active->SP, (size_t)task2.GetStack(), "expecting task2 after sleep");
 }
 
 static struct SleepAllAndWakeRelaxCpuContext
@@ -582,6 +695,18 @@ TEST(KernelServiceIsrSafety, Common)
         g_TestContext.ExpectAssert(true);
         Sleep(10);
         CHECK_TEXT(false, "Sleep is not allowed inside ISR");
+    }
+    catch (TestAssertPassed &pass)
+    {
+        CHECK(true);
+        g_TestContext.ExpectAssert(false);
+    }
+
+    try
+    {
+        g_TestContext.ExpectAssert(true);
+        SleepUntil(GetTicks() + 10);
+        CHECK_TEXT(false, "SleepUntil is not allowed inside ISR");
     }
     catch (TestAssertPassed &pass)
     {

--- a/test/generic/stktest_kernelservice.cpp
+++ b/test/generic/stktest_kernelservice.cpp
@@ -31,10 +31,10 @@ TEST(KernelService, GetMsecToTicks)
     mock.m_ticks = 1;
 
     mock.m_resolution = 1000;
-    CHECK_EQUAL(10, (int32_t)GetMsecFromTicks(10, mock.GetTickResolution()));
+    CHECK_EQUAL(10, (int32_t)GetMsFromTicks(10, mock.GetTickResolution()));
 
     mock.m_resolution = 10000;
-    CHECK_EQUAL(100, (int32_t)GetMsecFromTicks(10, mock.GetTickResolution()));
+    CHECK_EQUAL(100, (int32_t)GetMsFromTicks(10, mock.GetTickResolution()));
 }
 
 static struct DelayContext
@@ -156,7 +156,7 @@ TEST(KernelService, GetTicks)
     CHECK_EQUAL(2, (int32_t)stk::GetTicks());
 }
 
-TEST(KernelService, GetTimeNowMsec)
+TEST(KernelService, GetTimeNowMs)
 {
     Kernel<KERNEL_STATIC, 1, SwitchStrategyRR, PlatformTestMock> kernel;
     TaskMock<ACCESS_USER> task1;
@@ -166,17 +166,17 @@ TEST(KernelService, GetTimeNowMsec)
     kernel.AddTask(&task1);
     kernel.Start();
 
-    CHECK_EQUAL(0, (int32_t)stk::GetTimeNowMsec());
+    CHECK_EQUAL(0, (int32_t)stk::GetTimeNowMs());
 
     // make 1000 ticks
     for (int32_t i = 0; i < 1000; ++i)
         platform->ProcessTick();
 
     // 1000 usec * 1000 ticks = 1000 ms
-    CHECK_EQUAL(1000, (int32_t)stk::GetTimeNowMsec());
+    CHECK_EQUAL(1000, (int32_t)stk::GetTimeNowMs());
 }
 
-TEST(KernelService, GetTimeNowMsecWith10UsecTick)
+TEST(KernelService, GetTimeNowMsWith10UsecTick)
 {
     Kernel<KERNEL_STATIC, 1, SwitchStrategyRR, PlatformTestMock> kernel;
     TaskMock<ACCESS_USER> task1;
@@ -187,14 +187,14 @@ TEST(KernelService, GetTimeNowMsecWith10UsecTick)
     kernel.AddTask(&task1);
     kernel.Start();
 
-    CHECK_EQUAL(0, (int32_t)stk::GetTimeNowMsec());
+    CHECK_EQUAL(0, (int32_t)stk::GetTimeNowMs());
 
     // make 1000 ticks
     for (int32_t i = 0; i < 1000; ++i)
         platform->ProcessTick();
 
     // 10 usec * 1000 ticks = 10 ms
-    CHECK_EQUAL(10, (int32_t)stk::GetTimeNowMsec());
+    CHECK_EQUAL(10, (int32_t)stk::GetTimeNowMs());
 }
 
 static struct SwitchToNextRelaxCpuContext

--- a/test/generic/stktest_time.cpp
+++ b/test/generic/stktest_time.cpp
@@ -16,7 +16,7 @@ namespace test {
 // ============================= PeriodicTimer ================================ //
 // ============================================================================ //
 
-//! Mock of GetTimeNowMsec().
+//! Mock of GetTimeNowMs().
 namespace stk
 {
     static struct KernelServiceMock : public IKernelService
@@ -28,8 +28,8 @@ namespace stk
         TId GetTid() const { return 0; }
         Ticks GetTicks() const { return ticks; }
         int32_t GetTickResolution() const { return resolution; }
-        void Delay(Timeout msec) { (void)msec; }
-        void Sleep(Timeout msec) { (void)msec; }
+        void Delay(Timeout ticks) { (void)ticks; }
+        void Sleep(Timeout ticks) { (void)ticks; }
         void SwitchToNext() {}
         IWaitObject *Wait(ISyncObject *sobj, IMutex *mutex, Timeout timeout)
         {
@@ -46,7 +46,7 @@ namespace stk
         test::g_KernelService = &s_KernelServiceMock;
 
         s_KernelServiceMock.resolution = 1000;
-        s_KernelServiceMock.ticks = GetTicksFromMsec(now, s_KernelServiceMock.resolution);
+        s_KernelServiceMock.ticks = GetTicksFromMs(now, s_KernelServiceMock.resolution);
     }
 }
 

--- a/test/generic/stktest_time.cpp
+++ b/test/generic/stktest_time.cpp
@@ -30,6 +30,7 @@ namespace stk
         int32_t GetTickResolution() const { return resolution; }
         void Delay(Timeout ticks) { (void)ticks; }
         void Sleep(Timeout ticks) { (void)ticks; }
+        void SleepUntil(Ticks timestamp) { (void)timestamp; }
         void SwitchToNext() {}
         IWaitObject *Wait(ISyncObject *sobj, IMutex *mutex, Timeout timeout)
         {

--- a/test/hrt/stktest_hrt.cpp
+++ b/test/hrt/stktest_hrt.cpp
@@ -60,12 +60,12 @@ private:
     {
         for (int32_t i = 0; i < _STK_HRT_TEST_ITRS; ++i)
         {
-            int64_t start = GetTimeNowMsec();
+            int64_t start = GetTimeNowMs();
 
             // add varying workload (10, 20, 30 ms) with deadline max 50 ms
             Delay(_STK_HRT_TEST_SLEEP * (m_task_id + 1));
 
-            int64_t diff = GetTimeNowMsec() - start;
+            int64_t diff = GetTimeNowMs() - start;
 
             printf("id=%d start=%d diff=%d\n", m_task_id, (int)start, (int)diff);
 
@@ -104,7 +104,7 @@ int main(int argc, char **argv)
 
     kernel.Initialize();
 
-#define TICKS(MS) GetTicksFromMsec((MS), PERIODICITY_DEFAULT)
+#define TICKS(MS) GetTicksFromMs((MS), PERIODICITY_DEFAULT)
 
     kernel.AddTask(&task1, TICKS(_STK_HRT_TEST_PERIODICITY * _STK_HRT_TEST_TASKS_MAX), TICKS(_STK_HRT_TEST_PERIODICITY / 2), TICKS(_STK_HRT_TEST_PERIODICITY * 0));
 

--- a/test/mutex/test_mutex.cpp
+++ b/test/mutex/test_mutex.cpp
@@ -187,9 +187,9 @@ private:
             // Task 1: Try to acquire while held — must fail immediately
             stk::Sleep(_STK_MUTEX_TEST_SHORT_SLEEP); // Let task 0 acquire first
 
-            int64_t start = GetTimeNowMsec();
+            int64_t start = GetTimeNowMs();
             bool acquired = g_TestMutex.TryLock();
-            int64_t elapsed = GetTimeNowMsec() - start;
+            int64_t elapsed = GetTimeNowMs() - start;
 
             if (!acquired && (elapsed < _STK_MUTEX_TEST_SHORT_SLEEP))
                 g_TestResult = 1;
@@ -234,9 +234,9 @@ private:
             // Task 1: Try to acquire with timeout
             stk::Sleep(_STK_MUTEX_TEST_SHORT_SLEEP); // Let task 0 acquire first
 
-            int64_t start = GetTimeNowMsec();
+            int64_t start = GetTimeNowMs();
             bool acquired = g_TestMutex.TimedLock(50); // 50ms timeout
-            int64_t elapsed = GetTimeNowMsec() - start;
+            int64_t elapsed = GetTimeNowMs() - start;
 
             // Should timeout after ~50ms
             if (!acquired && elapsed >= 45 && elapsed <= 60)

--- a/test/pipe/test_pipe.cpp
+++ b/test/pipe/test_pipe.cpp
@@ -223,9 +223,9 @@ private:
         {
             // Read() on empty pipe with short timeout must expire and return false
             int32_t value   = -1;
-            int64_t start   = GetTimeNowMsec();
+            int64_t start   = GetTimeNowMs();
             bool    ok      = g_TestPipe.Read(value, 50);
-            int64_t elapsed = GetTimeNowMsec() - start;
+            int64_t elapsed = GetTimeNowMs() - start;
 
             if (!ok && elapsed >= 45 && elapsed <= 65)
                 ++g_SharedCounter; // 1: read timeout returned false in correct window
@@ -241,9 +241,9 @@ private:
                 g_TestPipe.Write(i, _STK_PIPE_TEST_TIMEOUT);
 
             // Write() on full pipe with short timeout must expire and return false
-            int64_t start   = GetTimeNowMsec();
+            int64_t start   = GetTimeNowMs();
             bool    ok      = g_TestPipe.Write(99, 50);
-            int64_t elapsed = GetTimeNowMsec() - start;
+            int64_t elapsed = GetTimeNowMs() - start;
 
             if (!ok && elapsed >= 45 && elapsed <= 65)
                 ++g_SharedCounter; // 2: write timeout returned false in correct window

--- a/test/rwmutex/test_rwmutex.cpp
+++ b/test/rwmutex/test_rwmutex.cpp
@@ -209,9 +209,9 @@ private:
             // Writer: wait briefly then attempt write lock (should not starve)
             stk::Sleep(_STK_RWMUTEX_TEST_SHORT_SLEEP);
 
-            int64_t start = GetTimeNowMsec();
+            int64_t start = GetTimeNowMs();
             g_TestRWMutex.Lock();
-            int64_t elapsed = GetTimeNowMsec() - start;
+            int64_t elapsed = GetTimeNowMs() - start;
 
             // Verify writer acquired within reasonable time (< 200ms)
             if (elapsed < 200)
@@ -260,9 +260,9 @@ private:
             stk::Sleep(_STK_RWMUTEX_TEST_SHORT_SLEEP);
 
             // TimedReadLock(50) must time out
-            int64_t start = GetTimeNowMsec();
+            int64_t start = GetTimeNowMs();
             bool acquired = g_TestRWMutex.TimedReadLock(50);
-            int64_t elapsed = GetTimeNowMsec() - start;
+            int64_t elapsed = GetTimeNowMs() - start;
 
             if (!acquired && elapsed >= 45 && elapsed <= 65)
                 ++g_SharedCounter; // 2: timed out correctly
@@ -328,9 +328,9 @@ private:
             stk::Sleep(_STK_RWMUTEX_TEST_SHORT_SLEEP);
 
             // TimedLock(50) must time out
-            int64_t start = GetTimeNowMsec();
+            int64_t start = GetTimeNowMs();
             bool acquired = g_TestRWMutex.TimedLock(50);
-            int64_t elapsed = GetTimeNowMsec() - start;
+            int64_t elapsed = GetTimeNowMs() - start;
 
             if (!acquired && elapsed >= 45 && elapsed <= 65)
                 ++g_SharedCounter; // 2: timed out correctly
@@ -393,9 +393,9 @@ private:
                 stk::Yield();
 
             // TryReadLock must fail immediately while writer holds lock
-            int64_t start = GetTimeNowMsec();
+            int64_t start = GetTimeNowMs();
             bool acquired = g_TestRWMutex.TryReadLock();
-            int64_t elapsed = GetTimeNowMsec() - start;
+            int64_t elapsed = GetTimeNowMs() - start;
 
             if (!acquired && elapsed < _STK_RWMUTEX_TEST_SHORT_SLEEP)
                 ++g_SharedCounter; // 2: correctly failed immediately
@@ -469,9 +469,9 @@ private:
             while (g_ReaderCount < 2)
                 stk::Yield();
 
-            int64_t start = GetTimeNowMsec();
+            int64_t start = GetTimeNowMs();
             g_TestRWMutex.Lock();
-            int64_t elapsed = GetTimeNowMsec() - start;
+            int64_t elapsed = GetTimeNowMs() - start;
 
             // Verify woken quickly after last reader released (< 50ms)
             if (g_SharedCounter == 1 && elapsed < 50)

--- a/test/semaphore/test_semaphore.cpp
+++ b/test/semaphore/test_semaphore.cpp
@@ -181,9 +181,9 @@ private:
             // Task 1: Wait with 50-tick timeout while semaphore stays at zero
             stk::Sleep(_STK_SEM_TEST_SHORT_SLEEP); // let task 0 establish the zero state
 
-            int64_t start   = GetTimeNowMsec();
+            int64_t start   = GetTimeNowMs();
             bool acquired   = g_TestSemaphore.Wait(50); // 50-tick timeout
-            int64_t elapsed = GetTimeNowMsec() - start;
+            int64_t elapsed = GetTimeNowMs() - start;
 
             // Should time out after ~50 ms and return false
             if (!acquired && elapsed >= 45 && elapsed <= 60)
@@ -234,9 +234,9 @@ private:
         if (m_task_id == 1)
         {
             // Wait(0) on a zero-count semaphore must return false immediately
-            int64_t start   = GetTimeNowMsec();
+            int64_t start   = GetTimeNowMs();
             bool acquired   = g_TestSemaphore.Wait(NO_WAIT);
-            int64_t elapsed = GetTimeNowMsec() - start;
+            int64_t elapsed = GetTimeNowMs() - start;
 
             if (!acquired && elapsed < _STK_SEM_TEST_SHORT_SLEEP)
                 ++g_SharedCounter;
@@ -247,9 +247,9 @@ private:
             // Pre-load one permit then Wait(0) must succeed immediately
             g_TestSemaphore.Signal();
 
-            int64_t start   = GetTimeNowMsec();
+            int64_t start   = GetTimeNowMs();
             bool acquired   = g_TestSemaphore.Wait(NO_WAIT);
-            int64_t elapsed = GetTimeNowMsec() - start;
+            int64_t elapsed = GetTimeNowMs() - start;
 
             if (acquired && elapsed < _STK_SEM_TEST_SHORT_SLEEP)
                 ++g_SharedCounter;

--- a/test/sleep/stktest_sleep.cpp
+++ b/test/sleep/stktest_sleep.cpp
@@ -51,11 +51,11 @@ private:
         // task 1: sleep 200 ms
         // task 2: sleep 300 ms
 
-        int64_t start = GetTimeNowMsec();
+        int64_t start = GetTimeNowMs();
 
         stk::Sleep(_STK_SLEEP_TEST_SLEEP_TIME * (m_task_id + 1));
 
-        int64_t diff = GetTimeNowMsec() - start;
+        int64_t diff = GetTimeNowMs() - start;
 
         printf("id=%d time=%d\n", m_task_id, (int)diff);
 

--- a/test/spinlock/test_spinlock.cpp
+++ b/test/spinlock/test_spinlock.cpp
@@ -209,9 +209,9 @@ private:
             while (g_SharedCounter == 0)
                 stk::Yield();
 
-            int64_t start   = GetTimeNowMsec();
+            int64_t start   = GetTimeNowMs();
             bool acquired   = g_TestSpinLock.TryLock();
-            int64_t elapsed = GetTimeNowMsec() - start;
+            int64_t elapsed = GetTimeNowMs() - start;
 
             // Must fail immediately: task 0 holds the lock
             if (!acquired && elapsed < _STK_SL_TEST_SHORT_SLEEP)

--- a/test/stktest.h
+++ b/test/stktest.h
@@ -162,6 +162,11 @@ public:
         m_event_handler->OnTaskSleep(GetCallerSP(), ticks);
     }
 
+    void SleepUntil(Ticks timestamp)
+    {
+        m_event_handler->OnTaskSleepUntil(GetCallerSP(), timestamp);
+    }
+
     IWaitObject *Wait(ISyncObject *sobj, IMutex *mutex, Timeout timeout)
     {
         return m_event_handler->OnTaskWait(GetCallerSP(), sobj, mutex, timeout);
@@ -291,6 +296,11 @@ public:
     void Sleep(Timeout ticks)
     {
         (void)ticks;
+    }
+
+    void SleepUntil(Ticks timestamp)
+    {
+        (void)timestamp;
     }
 
     void SwitchToNext()

--- a/test/timerhost/README.md
+++ b/test/timerhost/README.md
@@ -43,7 +43,7 @@ HeartbeatTimer g_Heartbeat;
 g_TimerHost.Initialize(&g_Kernel, stk::ACCESS_USER);
 
 // Start 500ms periodic heartbeat
-uint32_t period = stk::GetTicksFromMsec(500);
+uint32_t period = stk::GetTicksFromMs(500);
 g_TimerHost.Start(g_Heartbeat, period, period);
 ```
 

--- a/test/timerhost/test_timerhost.cpp
+++ b/test/timerhost/test_timerhost.cpp
@@ -68,7 +68,7 @@ public:
     {
         ++g_ExpiredCount;
         g_LastExpired[m_timer_id].Set();
-        g_ExpiredTime[m_timer_id] = GetTimeNowMsec();
+        g_ExpiredTime[m_timer_id] = GetTimeNowMs();
     }
 };
 
@@ -93,7 +93,7 @@ private:
 
         if (m_task_id == 1)
         {
-            int64_t start = GetTimeNowMsec();
+            int64_t start = GetTimeNowMs();
             g_TimerHost.Start(timer, 50); // 50-tick one-shot
 
             // Wait until timer fires
@@ -309,7 +309,7 @@ private:
                 stk::Sleep(_STK_TIMER_TEST_SHORT_SLEEP);
 
             // Reset: deadline should be now + 40ms
-            int64_t reset_time = GetTimeNowMsec();
+            int64_t reset_time = GetTimeNowMs();
             g_TimerHost.Reset(timer);
 
             // Wait for second firing
@@ -375,7 +375,7 @@ private:
             // Restart is asynchronous, wait for command to process
             stk::Sleep(2);
 
-            int64_t restart_time = GetTimeNowMsec();
+            int64_t restart_time = GetTimeNowMs();
 
             // Wait for next firing (count increases beyond count_before_restart)
             while (g_ExpiredCount <= count_before_restart)
@@ -452,7 +452,7 @@ private:
             // StartOrReset is asynchronous, wait for command to process
             stk::Sleep(2);
 
-            int64_t reset_time = GetTimeNowMsec();
+            int64_t reset_time = GetTimeNowMs();
 
             // Wait for second firing (count increases from 1 to 2)
             while (g_ExpiredCount == 1)


### PR DESCRIPTION
Additionally, modified behavior of `stk::Sleep` and `stk::Delay` to accept ticks, while for milliseconds there are new functions introduced: `stk::SleepMs` and `stk::DelayMs`.