### PR TITLE
Fix C interface compile by IAR EWARM.

### DIFF
--- a/build/example/driver/defs.h
+++ b/build/example/driver/defs.h
@@ -7,24 +7,16 @@
  * License: MIT License, see LICENSE for a full text.
  */
 
-#ifndef DRIVER_CPU_H_
-#define DRIVER_CPU_H_
+#ifndef DRIVER_DEFS_H_
+#define DRIVER_DEFS_H_
 
-#include "defs.h"
+#include <stdbool.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
+    #define STK_EXTERN extern "C"
+#else
+    #define STK_EXTERN extern
+#endif
 
-namespace bsp {
-
-struct Cpu
-{
-    static void Start(uint8_t cpu_id, void (*entry_func)(void));
-};
-
-} // namespace bsp
-
-#endif // __cplusplus
-
-STK_EXTERN void Cpu_Start(uint8_t cpu_id, void (*entry_func)(void));
-
-#endif /* DRIVER_CPU_H_ */
+#endif /* DRIVER_DEFS_H_ */

--- a/build/example/driver/led.h
+++ b/build/example/driver/led.h
@@ -10,8 +10,7 @@
 #ifndef DRIVER_LED_H_
 #define DRIVER_LED_H_
 
-#include <stdbool.h>
-#include <stdint.h>
+#include "defs.h"
 
 typedef enum LedId
 {
@@ -53,13 +52,11 @@ struct Led
 
 } // namespace bsp
 
-#else // __cplusplus
+#endif // __cplusplus
 
-void Led_Init(LedId led, bool init_state);
-void Led_InitAll(bool init_state);
-void Led_Set(LedId led, bool state);
-void Led_SwitchOnExclusive(LedId led);
-
-#endif
+STK_EXTERN void Led_Init(LedId led, bool init_state);
+STK_EXTERN void Led_InitAll(bool init_state);
+STK_EXTERN void Led_Set(LedId led, bool state);
+STK_EXTERN void Led_SwitchOnExclusive(LedId led);
 
 #endif /* DRIVER_LED_H_ */

--- a/build/example/timer/example.cpp
+++ b/build/example/timer/example.cpp
@@ -1,5 +1,5 @@
 /*
- * SuperTinyKernel™ (STK): Lightweight High-Performance Deterministic C++ RTOS for Embedded Systems.
+ * SuperTinyKernel(TM) RTOS: Lightweight High-Performance Deterministic C++ RTOS for Embedded Systems.
  *
  * Source: https://github.com/SuperTinyKernel-RTOS
  *

--- a/interop/c/include/stk_c.h
+++ b/interop/c/include/stk_c.h
@@ -586,9 +586,9 @@ stk_tick_t stk_ticks_from_ms(stk_time_t msec);
                Use this overload when the resolution is already cached to avoid
                a repeated call to stk_tick_resolution().
 */
-static inline stk_tick_t stk_ticks_from_ms_r(stk_time_t msec, int32_t resolution)
+static inline stk_tick_t stk_ticks_from_ms_r(stk_time_t msec, uint32_t resolution)
 {
-    return msec * 1000 / resolution;
+    return ((resolution != 0U) ? (msec * 1000LL / (stk_time_t)resolution) : 0LL);
 }
 
 /*! \brief     Returns current time in milliseconds since kernel start.
@@ -602,9 +602,9 @@ stk_time_t stk_time_now_ms(void);
     \return    Equivalent time in milliseconds.
     \note      ISR-safe (arithmetic only).
 */
-static inline stk_time_t stk_ms_from_ticks_r(stk_tick_t ticks, int32_t resolution)
+static inline stk_time_t stk_ms_from_ticks_r(stk_tick_t ticks, uint32_t resolution)
 {
-    return (ticks * resolution) / 1000;
+    return (stk_time_t)((ticks * (stk_tick_t)resolution) / 1000LL);
 }
 
 /*! \brief     Convert ticks to milliseconds using the current kernel tick resolution.

--- a/interop/c/src/stk_c.cpp
+++ b/interop/c/src/stk_c.cpp
@@ -21,6 +21,17 @@
 #define STK_TIMER_COUNT_MAX (STK_C_TIMER_MAX)
 #include "time/stk_time.h"
 
+// Check correctness of stk_config.h
+#ifndef STK_C_KERNEL_TYPE_CPU_0
+#error "Missing STK_C_KERNEL_TYPE_CPU_0: Kernel type for CPU0 must be defined via stk_config.h or compiler flags."
+#endif
+#ifndef STK_C_CPU_COUNT
+#error "Missing STK_C_CPU_COUNT: CPU count must be defined via stk_config.h or compiler flags."
+#endif
+#ifndef STK_C_KERNEL_MAX_TASKS
+#error "Missing STK_C_KERNEL_MAX_TASKS: max task count must be defined via stk_config.h or compiler flags."
+#endif
+
 using namespace stk;
 
 #define STK_C_TASKS_MAX (STK_C_KERNEL_MAX_TASKS)
@@ -33,35 +44,43 @@ struct stk_task_t;
 class TaskWrapper final : public ITask
 {
 public:
+    explicit TaskWrapper() : m_func(nullptr), m_user_data(nullptr), m_stack(nullptr), 
+        m_stack_size(0U), m_mode(ACCESS_USER), m_weight(DEFAULT_WEIGHT), m_tname(nullptr)
+    {}
+    
+    /*! \brief Destructor.
+        \note  MISRA deviation: [STK-DEV-005] Rule 10-3-2.
+    */
+    ~TaskWrapper() = default;
+  
     // ITask
-    EAccessMode GetAccessMode() const override { return m_mode; }
-    void OnDeadlineMissed(uint32_t duration) override { (void)duration; }
-    int32_t GetWeight() const override { return m_weight; }
-    const char *GetTraceName() const override { return m_tname; }
+    EAccessMode GetAccessMode()              const override { return m_mode; }
+    void OnDeadlineMissed(uint32_t duration)       override { (void)duration; }
+    int32_t GetWeight()                      const override { return m_weight; }
+    const char *GetTraceName()               const override { return m_tname; }
 
     // IStackMemory
-    stk_word_t *GetStack() const override { return m_stack; }
-    size_t GetStackSize() const override { return m_stack_size; }
+    const Word *GetStack()     const override { return m_stack; }
+    size_t GetStackSize()      const override { return m_stack_size; }
     size_t GetStackSizeBytes() const override { return m_stack_size * sizeof(stk_word_t); }
 
-    void Initialize(stk_task_entry_t func,
-                    void       *user_data,
-                    stk_word_t  *stack,
-                    size_t      stack_size,
-                    EAccessMode mode)
+    void Initialize(stk_task_entry_t func, void *user_data, stk_word_t *stack,
+        size_t stack_size, EAccessMode mode)
     {
         m_func       = func;
         m_user_data  = user_data;
         m_stack      = stack;
         m_stack_size = stack_size;
         m_mode       = mode;
-        m_weight     = 1;
+        m_weight     = DEFAULT_WEIGHT;
     }
 
-    void SetWeight(int32_t weight) { m_weight = weight; }
+    void SetWeight(Weight weight) { m_weight = weight; }
     void SetName(const char *tname) { m_tname = tname; }
 
 private:
+    STK_NONCOPYABLE_CLASS(TaskWrapper);
+  
     void Run() override { m_func(m_user_data); }
     void OnExit() override { FreeTask(ToStkTask()); }
 
@@ -73,7 +92,7 @@ private:
     stk_word_t      *m_stack;
     size_t           m_stack_size;
     EAccessMode      m_mode;
-    int32_t          m_weight;
+    Weight           m_weight;
     const char      *m_tname;
 };
 
@@ -239,12 +258,19 @@ extern "C" {
 // -----------------------------------------------------------------------------
 // Kernel create/destroy wrappers
 // -----------------------------------------------------------------------------
+#define STK_PP_CAT(A, B)        A##B
+#define STK_PP_CAT_EXPAND(A, B) STK_PP_CAT(A, B)
+#define STK_KERNEL_TYPE(X)      STK_PP_CAT(STK_C_KERNEL_TYPE_CPU_, X)
+#define STK_KERNEL_MEM(X)       STK_PP_CAT_EXPAND(kernel_, STK_PP_CAT_EXPAND(X, _mem))
 #define STK_KERNEL_CASE(X) \
     case X: \
     { \
-        STK_STATIC_ASSERT_N(sizeof(STK_C_KERNEL_TYPE_CPU_##X) % sizeof(Word) == 0, "Kernel memory size must be multiple of Word"); \
-        alignas(alignof(STK_C_KERNEL_TYPE_CPU_##X)) static Word kernel_##X##_mem[sizeof(STK_C_KERNEL_TYPE_CPU_##X) / sizeof(Word)]; \
-        IKernel *kernel = new (kernel_##X##_mem) STK_C_KERNEL_TYPE_CPU_##X(); \
+        using KernelType_ = STK_KERNEL_TYPE(X); \
+        STK_STATIC_ASSERT_N(((sizeof(KernelType_) % sizeof(Word)) == 0U), \
+                            "Kernel memory size must be multiple of Word"); \
+        alignas(alignof(KernelType_)) \
+        static Word STK_KERNEL_MEM(X)[sizeof(KernelType_) / sizeof(Word)]; \
+        IKernel *kernel = new (STK_KERNEL_MEM(X)) KernelType_(); \
         RegisterKernel(kernel, X); \
         return reinterpret_cast<stk_kernel_t *>(kernel); \
     }

--- a/interop/c/src/stk_c_sync.cpp
+++ b/interop/c/src/stk_c_sync.cpp
@@ -715,7 +715,7 @@ stk_rwmutex_t *stk_rwmutex_create(stk_rwmutex_mem_t *memory, uint32_t memory_siz
     if (memory_size < sizeof(stk_rwmutex_t))
         return nullptr;
 
-    return (stk_rwmutex_t *)new (memory->data) stk_rwmutex_t{};
+    return (stk_rwmutex_t *)new (memory->data) stk_rwmutex_t();
 }
 
 void stk_rwmutex_destroy(stk_rwmutex_t *rw)

--- a/interop/c/src/stk_c_time.cpp
+++ b/interop/c/src/stk_c_time.cpp
@@ -59,9 +59,9 @@ public:
         m_host_handle = nullptr;
     }
 
-    stk_timer_callback_t GetCallback() const { return m_callback; }
-    void *GetUserData() const { return m_user_data; }
-    stk_timerhost_t *GetHostHandle() const { return m_host_handle; }
+    stk_timer_callback_t GetCallback() { return m_callback; }
+    void *GetUserData() { return m_user_data; }
+    stk_timerhost_t *GetHostHandle() { return m_host_handle; }
 
     void OnExpired(TimerHost */*host*/) override
     {

--- a/stk/include/arch/arm/cortex-m/stk_arch_arm-cortex-m.h
+++ b/stk/include/arch/arm/cortex-m/stk_arch_arm-cortex-m.h
@@ -27,8 +27,7 @@ public:
     /*! \brief Destructor.
         \note  MISRA deviation: [STK-DEV-005] Rule 10-3-2.
     */
-    ~PlatformArmCortexM()
-    {}
+    ~PlatformArmCortexM() = default;
 
     void Initialize(IEventHandler *event_handler, IKernelService *service, uint32_t resolution_us, Stack *exit_trap) override;
     void Start() override;

--- a/stk/include/arch/stk_arch_common.h
+++ b/stk/include/arch/stk_arch_common.h
@@ -31,8 +31,7 @@ public:
     /*! \brief Destructor.
         \note  MISRA deviation: [STK-DEV-005] Rule 10-3-2.
     */
-    ~PlatformContext()
-    {}
+    ~PlatformContext() = default;
 
     /*! \brief     Initialize context.
         \param[in] handler: Event handler.
@@ -56,15 +55,17 @@ public:
     */
     static inline Word *InitStackMemory(IStackMemory *memory)
     {
-        size_t stack_size = memory->GetStackSize();
-        Word *itr = memory->GetStack();
-        Word *stack_top = itr + stack_size;
+        const size_t stack_size = memory->GetStackSize();
+        Word *itr = const_cast<Word *>(memory->GetStack());
+        Word *const stack_top = itr + stack_size;
 
         STK_ASSERT(stack_size >= STACK_SIZE_MIN);
 
         // initialization of the stack memory satisfies stack integrity check in Kernel::StateSwitch
         while (itr < stack_top)
+        {
             *itr++ = STK_STACK_MEMORY_FILLER;
+        }
 
         // expecting STK_STACK_MEMORY_ALIGN-byte aligned memory for a stack
         STK_ASSERT((hw::PtrToWord(stack_top) & (STK_STACK_MEMORY_ALIGN - 1)) == 0U);

--- a/stk/include/stk.h
+++ b/stk/include/stk.h
@@ -125,7 +125,7 @@ protected:
             \brief Bitmask of transient state flags. Set by the task or the kernel and
                    consumed (cleared) during UpdateTaskState() on the next tick.
         */
-        enum EStateFlags
+        enum EStateFlags : uint32_t
         {
             STATE_NONE           = 0,        //!< No pending state flags.
             STATE_REMOVE_PENDING = (1 << 0), //!< Task returned from its Run function; slot will be freed on the next tick (KERNEL_DYNAMIC only).
@@ -528,8 +528,8 @@ protected:
         */
         bool IsMemoryOfSP(Word SP) const
         {
-            Word *start = m_user->GetStack();
-            Word *end   = start + m_user->GetStackSize();
+            const Word *const start = m_user->GetStack();
+            const Word *const end   = start + m_user->GetStackSize();
 
             return (SP >= hw::PtrToWord(start)) && (SP <= hw::PtrToWord(end));
         }

--- a/stk/include/stk_arch.h
+++ b/stk/include/stk_arch.h
@@ -377,9 +377,10 @@ __stk_forceinline T ReadVolatile64(volatile const T *addr)
     {
         // 32-bit arch: split the 64-bit address into two 32-bit halves.
         // Writer always updates hi before lo (see WriteVolatile64), so if hi is
-        // the same before and after reading lo, no write straddled the two reads.
-        volatile const uint32_t *plo = &((volatile const uint32_t *)addr)[STK_ENDIAN_IDX_LO];
-        volatile const uint32_t *phi = &((volatile const uint32_t *)addr)[STK_ENDIAN_IDX_HI];
+        // the same before and after reading lo, no write straddled the two reads.        
+        volatile const uint32_t *const p_base = reinterpret_cast<volatile const uint32_t *>(addr);
+        volatile const uint32_t *const plo = &p_base[STK_ENDIAN_IDX_LO];
+        volatile const uint32_t *const phi = &p_base[STK_ENDIAN_IDX_HI];
 
         uint32_t hi, lo;
         do
@@ -392,7 +393,7 @@ __stk_forceinline T ReadVolatile64(volatile const T *addr)
         }
         while (hi != (*phi)); // hi changed: a write occurred during the read; retry
 
-        return ((uint64_t)hi << 32) | lo;
+        return (static_cast<uint64_t>(hi) << 32) | lo;
     }
 }
 
@@ -429,15 +430,16 @@ __stk_forceinline void WriteVolatile64(volatile T *addr, T value)
     }
     else
     {
-        volatile uint32_t *plo = &((volatile uint32_t *)addr)[STK_ENDIAN_IDX_LO];
-        volatile uint32_t *phi = &((volatile uint32_t *)addr)[STK_ENDIAN_IDX_HI];
+        volatile uint32_t *const p_base = reinterpret_cast<volatile uint32_t *>(addr);
+        volatile uint32_t *const plo = &p_base[STK_ENDIAN_IDX_LO];
+        volatile uint32_t *const phi = &p_base[STK_ENDIAN_IDX_HI];
 
         // Write hi first: ReadVolatile64 reads hi twice and retries if it changed,
         // so writing hi before lo ensures readers can detect a torn write.
-        (*phi) = (uint32_t)(value >> 32);
+        (*phi) = static_cast<uint32_t>(static_cast<uint64_t>(value) >> 32);
         __stk_full_memfence();
 
-        (*plo) = (uint32_t)value;
+        (*plo) = static_cast<uint32_t>(value);
     }
 }
 

--- a/stk/include/stk_common.h
+++ b/stk/include/stk_common.h
@@ -256,7 +256,7 @@ class IStackMemory
 public:
     /*! \brief   Get pointer to the stack memory.
     */
-    virtual Word *GetStack() const = 0;
+    virtual const Word *GetStack() const = 0;
 
     /*! \brief   Get number of elements of the stack memory array.
     */
@@ -383,8 +383,7 @@ public:
     /*! \brief Destructor.
         \note  MISRA deviation: [STK-DEV-005] Rule 10-3-2.
     */
-    ~ISyncObject()
-    {}
+    ~ISyncObject() = default;
 
     /*! \typedef   ListHeadType
         \brief     List head type for ISyncObject elements.
@@ -575,7 +574,8 @@ public:
                    IKernelTask::GetWeight, IKernelService::InheritWeight, IKernelService::RestoreWeight
     */
     virtual Weight GetWeight() const { return DEFAULT_WEIGHT; }
-    /*! \brief     Get task Id set by application.
+
+    /*! \brief     Get task Id set by application.
         \return    Application-defined task identifier. Return 0 if unused.
         \note      Used for debugging and tracing only. The kernel does not interpret this value.
     */

--- a/stk/include/stk_defs.h
+++ b/stk/include/stk_defs.h
@@ -428,7 +428,7 @@
            Can be overridden by defining STK_STACK_MEMORY_FILLER before including this header or in stk_config.h.
 */
 #ifndef STK_STACK_MEMORY_FILLER
-    #define STK_STACK_MEMORY_FILLER ((stk::Word)((sizeof(stk::Word) <= 4U) ? 0xdeadbeef : 0xdeadbeefdeadbeef))
+    #define STK_STACK_MEMORY_FILLER ((stk::Word)((sizeof(stk::Word) <= 4U) ? 0xdeadbeefu : 0xdeadbeefdeadbeefull))
 #endif
 
 /*! \def   STK_STACK_MEMORY_ALIGN

--- a/stk/include/stk_helper.h
+++ b/stk/include/stk_helper.h
@@ -51,9 +51,9 @@ class Task : public ITask
 public:
     enum { STACK_SIZE = _StackSize }; //!< Stack size in elements of Word, mirrors the _StackSize template parameter.
 
-    Word *GetStack() const override { return const_cast<Word *>(m_stack); }
-    size_t GetStackSize() const override { return _StackSize; }
-    size_t GetStackSizeBytes() const override { return _StackSize * sizeof(Word); }
+    const Word *GetStack()      const override { return const_cast<Word *>(m_stack); }
+    size_t GetStackSize()       const override { return _StackSize; }
+    size_t GetStackSizeBytes()  const override { return _StackSize * sizeof(Word); }
     EAccessMode GetAccessMode() const override { return _AccessMode; }
 
 protected:
@@ -72,8 +72,7 @@ protected:
     /*! \brief Destructor.
         \note  MISRA deviation: [STK-DEV-005] Rule 10-3-2.
     */
-    ~Task()
-    {}
+    ~Task() = default;
 
 private:
     typename StackMemoryDef<_StackSize>::Type m_stack; //!< Stack memory region, 16-byte aligned.
@@ -99,11 +98,11 @@ class TaskW : public ITask
 public:
     enum { STACK_SIZE = _StackSize }; //!< Stack size in elements of Word, mirrors the _StackSize template parameter.
 
-    Word *GetStack() const override { return const_cast<Word *>(m_stack); }
-    size_t GetStackSize() const override { return _StackSize; }
-    size_t GetStackSizeBytes() const override { return _StackSize * sizeof(Word); }
+    const Word *GetStack()      const override { return const_cast<Word *>(m_stack); }
+    size_t GetStackSize()       const override { return _StackSize; }
+    size_t GetStackSizeBytes()  const override { return _StackSize * sizeof(Word); }
     EAccessMode GetAccessMode() const override { return _AccessMode; }
-    Weight GetWeight() const override { return _Weight; }
+    Weight GetWeight()          const override { return _Weight; }
 
 protected:
     STK_NONCOPYABLE_CLASS(TaskW);
@@ -120,8 +119,7 @@ protected:
     /*! \brief Destructor.
         \note  MISRA deviation: [STK-DEV-005] Rule 10-3-2.
     */
-    ~TaskW()
-    {}
+    ~TaskW() = default;
 
 private:
     typename StackMemoryDef<_StackSize>::Type m_stack; //!< Stack memory region, 16-byte aligned.
@@ -156,12 +154,11 @@ public:
     /*! \brief Destructor.
         \note  MISRA deviation: [STK-DEV-005] Rule 10-3-2.
     */
-    ~StackMemoryWrapper()
-    {}
+    ~StackMemoryWrapper() = default;
 
     /*! \brief Get pointer to the first element of the wrapped stack array.
     */
-    Word *GetStack() const override { return (*m_stack); }
+    const Word *GetStack() const override { return (*m_stack); }
 
     /*! \brief Get number of elements in the wrapped stack array.
     */
@@ -243,9 +240,9 @@ __stk_forceinline TId GetTid()
     \return    Equivalent time in milliseconds.
     \note      ISR-safe (performs only arithmetic, no kernel calls).
 */
-__stk_forceinline Time GetMsFromTicks(Ticks ticks, int32_t resolution)
+__stk_forceinline Time GetMsFromTicks(Ticks ticks, uint32_t resolution)
 {
-    return (ticks * resolution) / 1000;
+    return static_cast<Time>((ticks * static_cast<Ticks>(resolution)) / 1000LL);
 }
 
 /*! \brief     Convert milliseconds to ticks.
@@ -254,9 +251,9 @@ __stk_forceinline Time GetMsFromTicks(Ticks ticks, int32_t resolution)
     \return    Equivalent tick count.
     \note      ISR-safe (performs only arithmetic, no kernel calls).
 */
-__stk_forceinline Ticks GetTicksFromMs(Time ms, int32_t resolution)
+__stk_forceinline Ticks GetTicksFromMs(Time ms, uint32_t resolution)
 {
-    return ((resolution != 0) ? (ms * 1000 / resolution) : 0);
+    return static_cast<Ticks>(((resolution != 0U) ? (ms * 1000LL / static_cast<Time>(resolution)) : 0LL));
 }
 
 /*! \brief     Get number of ticks elapsed since kernel start.

--- a/stk/include/time/stk_time_timer.h
+++ b/stk/include/time/stk_time_timer.h
@@ -339,7 +339,7 @@ private:
         const char *GetTraceName()  const override { return nullptr; }
 
         // IStackMemory
-        Word *GetStack()            const override { return m_stack; }
+        const Word *GetStack()      const override { return m_stack; }
         size_t GetStackSize()       const override { return m_stack_size; }
         size_t GetStackSizeBytes()  const override { return (m_stack_size * sizeof(Word)); }
 

--- a/stk/src/arch/arm/cortex-m/stk_arch_arm-cortex-m.cpp
+++ b/stk/src/arch/arm/cortex-m/stk_arch_arm-cortex-m.cpp
@@ -951,8 +951,7 @@ static struct Context final : public PlatformContext
     /*! \brief Destructor.
         \note  MISRA deviation: [STK-DEV-005] Rule 10-3-2.
     */
-    ~Context()
-    {}
+    ~Context() = default;
 
     void Initialize(IPlatform::IEventHandler *handler, IKernelService *service, Stack *exit_trap,
         uint32_t resolution_us) override
@@ -1306,7 +1305,12 @@ Timeout Context::ReloadTickPeriod(Timeout ticks_requested)
 {
     const uint32_t SYSTICK_MAX_LOAD = 0x00FFFFFFu; // SysTick LOAD register is 24-bit
     const uint32_t reload = static_cast<uint32_t>(ConvertTimeUsToClockCycles(HW_CoreClockFrequency(), m_tick_resolution));
-
+    if (reload == 0U)
+    {
+        STK_ASSERT(false);
+        return NO_WAIT;
+    }
+        
     // guard against uint32_t overflow in the reload calculation
     STK_ASSERT(static_cast<uint64_t>(ticks_requested) * reload <= UINT32_MAX);
 
@@ -1682,7 +1686,11 @@ void Context::OnStart()
 Timeout Context::Suspend()
 {
     const uint32_t resolution = static_cast<uint32_t>(ConvertTimeUsToClockCycles(HW_CoreClockFrequency(), m_tick_resolution));
-    STK_ASSERT(resolution != 0);
+    if (resolution == 0U)
+    {
+        STK_ASSERT(false);
+        return NO_WAIT;
+    }
 
     HW_DisableInterrupts();
 

--- a/stk/src/arch/x86/win32/stk_arch_x86-win32.cpp
+++ b/stk/src/arch/x86/win32/stk_arch_x86-win32.cpp
@@ -609,7 +609,9 @@ bool Context::InitStack(EStackType stack_type, Stack *stack, IStackMemory *stack
 {
     InitStackMemory(stack_memory);
 
-    TaskContext *ctx = reinterpret_cast<TaskContext *>(STK_X86_WIN32_GET_SP(stack_memory->GetStack()));
+    Word * const stack_mem = const_cast<Word *>(stack_memory->GetStack());
+
+    TaskContext * const ctx = reinterpret_cast<TaskContext *>(STK_X86_WIN32_GET_SP(stack_mem));
 
     switch (stack_type)
     {

--- a/test/generic/stktest_misc.cpp
+++ b/test/generic/stktest_misc.cpp
@@ -118,8 +118,9 @@ TEST(UserTask, GetStackSpace)
     CHECK_EQUAL(TaskMock<ACCESS_USER>::STACK_SIZE, space);
 
     // write something to bottom
-    task.GetStack()[task.GetStackSize() - 1] = 0x12345678;
-    task.GetStack()[task.GetStackSize() - 2] = 0x12345678;
+    Word *stack_mem = const_cast<Word *>(task.GetStack());
+    stack_mem[task.GetStackSize() - 1] = 0x12345678;
+    stack_mem[task.GetStackSize() - 2] = 0x12345678;
 
     space = task.GetStackSpace();
 


### PR DESCRIPTION
- Protect C interface from missing configuring definitions.
- Fix C interface compile by IAR.
- Modify `IStackMemory::GetStack()` API to return const `Word` pointer in order to protect memory from unintentional write ops (see example `TEST(UserTask, GetStackSpace)`). Minor cleanup to remove IAR compiler warnings.
- Minor cleanup to make IAR more happy.