### PR TITLE
Refactor implementation to comply with MISRA rules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,23 +21,24 @@
 
 STK combines the control and transparency of bare-metal development with the structure and maintainability of modern, type-safe C++.
 
-### For Embedded Developers
+You get:
 
-- **Deterministic execution** — no dynamic memory allocation (`malloc/free`) and no heap fragmentation. Memory usage is fully predictable at compile time.
-- **Lightweight C++ architecture** — clean object-oriented design without STL dependencies, exceptions, RTTI, or heavy runtime abstractions.
-- **Native C interoperability** — fully featured C API available for pure C projects and mixed C/C++ codebases.
-- **Transparent implementation** — minimal wrapper macros and readable scheduler internals simplify debugging and tracing.
-- **Portable design** — minimal BSP surface and straightforward architecture porting.
+- **C++ native RTOS** — Built so the C++ compiler can efficiently optimize your STK-based application for maximum speed and ultra-low overhead.
+- **Safe code from day one** — Thoughtful OOP design enforces strict encapsulation and type safety to deliver secure, robust, and high-performance firmware.
+- **Full-featured RTOS** — A comprehensive suite of thread synchronization, memory, and time management primitives. You only need to bring your own HAL.
+- **Safety-critical ready** — Built for strict compliance with MISRA standards. Looking for a safe C++ RTOS for your certified device? Explore our [Services](#services). 
+- **Deterministic execution** — Zero dynamic memory allocation (`malloc`/`free`) and zero heap fragmentation. Memory usage is fully predictable at compile time.
+- **Clean C++ design** — No STL dependencies, exceptions, RTTI, or heavy runtime abstractions. Readable internals simplify debugging and tracing.
+- **Verbose-free code** — A clean C++ API makes your implementation highly concise, making it significantly easier to maintain, refactor, and debug than standard C-only APIs.
+- **Portable design** — Minimal BSP (Board Support Package) footprint with complete independence from specific board and MCU peripherals.
+- **Reduced hardware requirements** — Compact kernel footprint that allows you to deploy on lower-RAM, lower-cost MCU variants.
+- **Higher CPU availability** — More time for your application logic. Benchmarks show up to **~12% more application CPU time** compared to FreeRTOS under comparable workloads (see [Benchmark](#benchmark)).
+- **Lower power consumption** — Features ultra-low power, tickless scheduling paired with reduced overhead, enabling the use of lower-frequency MCUs to save battery of your portable design.
+- **Native C support** — Includes a fully featured C API wrapper, allowing you to seamlessly use STK in pure C projects.
+- **Simplified migration** — Drop-in compatibility layers for FreeRTOS and CMSIS-RTOS2 to help you migrate legacy codebases with minimal application changes.
+- **B2B professional support** — Engineered for seamless integration into commercial projects. Explore our [Services](#services) for enterprise-grade support and custom engineering.
 
-### For Technical Leads and Product Teams
-
-- **Reduced hardware requirements** — the compact kernel footprint can enable the use of lower-RAM or lower-cost MCU variants.
-- **Higher CPU availability for applications** — benchmarks show up to **~12% more application CPU time** compared to FreeRTOS under comparable workloads (see [Benchmark](#benchmark)).
-- **Lower power potential** — reduced scheduling overhead can help meet timing requirements at lower MCU clock frequencies.
-- **Simplified migration** — compatibility layers for FreeRTOS and CMSIS-RTOS2 allow existing projects to migrate with minimal application changes.
-- **Predictable system behavior** — static allocation and deterministic scheduling simplify validation, debugging, and long-term maintenance.
-
-> STK does not attempt to abstract or manage MCU peripherals. Its purpose is to provide a fast, predictable, and memory-efficient scheduling core for embedded applications.
+> STK does not attempt to abstract or manage MCU peripherals, similarly to FreeRTOS or CMSIS-RTOS2.
 
 STK is an open-source project developed at https://github.com/SuperTinyKernel-RTOS.
 
@@ -323,6 +324,13 @@ A complete ultra-low power demo targeting the [STM32F407G-DISC1](https://www.st.
 * GCC
 * Clang/ARMCC 6 and higher
 * IAR EWARM 8.0 and higher (ARM only)
+
+---
+
+## Language
+
+* Minimal: C++11
+* Recommended: C++17 and higher
 
 ---
 
@@ -963,7 +971,7 @@ You may freely use it in projects of any type:
 
 ---
 
-## 🔒 Professional Services & Commercial Licensing
+## Services
 
 While **SuperTinyKernel™ RTOS** is provided under the permissive MIT license, we offer dedicated professional services for organizations integrating STK into production-grade, mission-critical, or regulated environments.
 

--- a/build/benchmark/eclipse/perf-stm32f407g-disc1-stk/src/main.cpp
+++ b/build/benchmark/eclipse/perf-stm32f407g-disc1-stk/src/main.cpp
@@ -32,7 +32,7 @@ extern "C" void SysTick_Handler()
     if (g_Enable)
         ++g_Ticks;
 
-    if (g_Kernel.GetState() == stk::IKernel::STATE_RUNNING)
+    if (g_Kernel.GetState() == stk::IKernel::KSTATE_RUNNING)
         g_Kernel.GetPlatform()->ProcessTick();
 }
 

--- a/build/example/driver/led.h
+++ b/build/example/driver/led.h
@@ -39,14 +39,18 @@ struct Led
     static void Init(Id led, bool init_state);
     static inline void InitAll(bool init_state)
     {
-        for (uint8_t led = 0; led < LED_MAX; ++led)
+        for (uint8_t led = 0U; led < LED_MAX; ++led)
+        {
             Led::Init(static_cast<LedId>(led), init_state);
+        }
     }
     static void Set(Id led, bool state);
     static void SwitchOnExclusive(Id led)
     {
-        for (uint8_t i = 0; i < LED_MAX; ++i)
+        for (uint8_t i = 0U; i < LED_MAX; ++i)
+        {
             Led::Set(static_cast<LedId>(i), (i == led));
+        }
     }
 };
 

--- a/interop/c/include/stk_c.h
+++ b/interop/c/include/stk_c.h
@@ -321,18 +321,18 @@ void stk_kernel_start(stk_kernel_t *k);
     \note      It is a direct match for IKernel::EState enum.
     \see       stk_kernel_get_state()
 */
-typedef enum _EKernelState {
+typedef enum stk_kernel_state_t {
     STK_KERNEL_STATE_INACTIVE  = 0, //!< not ready, stk_kernel_init() must be called
     STK_KERNEL_STATE_READY     = 1, //!< ready to start, stk_kernel_start() must be called
     STK_KERNEL_STATE_RUNNING   = 2, //!< initialized and running, stk_kernel_start() was called successfully
     STK_KERNEL_STATE_SUSPENDED = 3  //!< scheduling suspended via stk_kernel_service_suspend() (tickless idle)
-} EKernelState;
+} stk_kernel_state_t;
 
 /*! \brief     Get state of the scheduler.
     \param[in] k: Kernel handle.
-    \return    State value, see \a EKernelState.
+    \return    State value, see \a stk_kernel_state_t.
 */
-EKernelState stk_kernel_get_state(const stk_kernel_t *k);
+stk_kernel_state_t stk_kernel_get_state(const stk_kernel_t *k);
 
 /*! \brief     Test whether currently configured task set is schedulable.
     \param[in] k: Kernel handle.
@@ -567,7 +567,7 @@ stk_tick_t stk_ticks(void);
 /*! \brief     Returns how many microseconds correspond to one kernel tick.
     \return    Tick resolution in microseconds.
 */
-int32_t stk_tick_resolution(void);
+uint32_t stk_tick_resolution(void);
 
 /*! \brief     Get ticks from milliseconds using current kernel tick resolution.
     \param[in] msec: Milliseconds to convert.
@@ -763,12 +763,12 @@ void stk_tls_set(void *ptr);
 /*! \brief     Typed helper for getting TLS value.
     \note      Expands to ((type *)stk_tls_get())
 */
-#define STK_TLS_GET(type) ((type *)stk_tls_get())
+#define STK_TLS_GET_T(type) ((type *)stk_tls_get())
 
 /*! \brief     Typed helper for setting TLS value.
     \note      Expands to stk_tls_set((void *)(ptr))
 */
-#define STK_TLS_SET(ptr) stk_tls_set((void *)(ptr))
+#define STK_TLS_SET_T(ptr) stk_tls_set((void *)(ptr))
 
 // =============================================================================
 // Synchronization Primitives

--- a/interop/c/include/stk_c_memory.h
+++ b/interop/c/include/stk_c_memory.h
@@ -71,7 +71,7 @@ extern "C" {
     \note    Increase if your application needs more simultaneous pools.
 */
 #ifndef STK_C_BLOCKPOOL_MAX
-    #define STK_C_BLOCKPOOL_MAX 8
+    #define STK_C_BLOCKPOOL_MAX 8U
 #endif
 
 // =============================================================================

--- a/interop/c/src/stk_c.cpp
+++ b/interop/c/src/stk_c.cpp
@@ -139,17 +139,25 @@ public:
     // IPlatform::IEventOverrider
     bool OnSleep(Timeout sleep_ticks) override
     {
+        bool is_handled = false;
+      
         if ((m_cb != nullptr) && (m_cb->on_sleep != nullptr))
-            return m_cb->on_sleep(static_cast<stk_timeout_t>(sleep_ticks), m_cb->user_data);
+        {
+            is_handled = m_cb->on_sleep(static_cast<stk_timeout_t>(sleep_ticks), m_cb->user_data);
+        }
 
-        return false;
+        return is_handled;
     }
     bool OnHardFault() override
     {
+        bool is_handled = false;
+      
         if ((m_cb != nullptr) && (m_cb->on_hard_fault != nullptr))
-            return m_cb->on_hard_fault(m_cb->user_data);
+        {
+            is_handled = m_cb->on_hard_fault(m_cb->user_data);
+        }
 
-        return false;
+        return is_handled;
     }
 
 private:
@@ -320,7 +328,6 @@ void stk_kernel_destroy(stk_kernel_t *k)
     // GetPlatform() paths, and we must not leave a dangling overrider pointer
     // registered at that point.
     UnregisterKernel(reinterpret_cast<IKernel *>(k));
-    reinterpret_cast<IKernel *>(k)->~IKernel();
 }
 
 // -----------------------------------------------------------------------------
@@ -340,11 +347,11 @@ void stk_kernel_start(stk_kernel_t *k)
     reinterpret_cast<IKernel *>(k)->Start();
 }
 
-EKernelState stk_kernel_get_state(const stk_kernel_t *k)
+stk_kernel_state_t stk_kernel_get_state(const stk_kernel_t *k)
 {
     STK_ASSERT(k != nullptr);
 
-    return static_cast<EKernelState>(reinterpret_cast<const stk::IKernel *>(k)->GetState());
+    return static_cast<stk_kernel_state_t>(reinterpret_cast<const stk::IKernel *>(k)->GetState());
 }
 
 bool stk_kernel_is_schedulable(const stk_kernel_t *k)
@@ -375,8 +382,8 @@ bool stk_kernel_is_started(const stk_kernel_t *k)
 {
     STK_ASSERT(k != nullptr);
 
-    const stk::IKernel::EState st = reinterpret_cast<const stk::IKernel *>(k)->GetState();
-    return ((st == stk::IKernel::STATE_RUNNING) || (st == stk::IKernel::STATE_SUSPENDED));
+    const stk::IKernel::EKernelState st = reinterpret_cast<const stk::IKernel *>(k)->GetState();
+    return ((st == stk::IKernel::KSTATE_RUNNING) || (st == stk::IKernel::KSTATE_SUSPENDED));
 }
 
 void stk_kernel_schedule_task_removal(stk_kernel_t *k, stk_task_t *task)
@@ -409,16 +416,23 @@ size_t stk_kernel_enumerate_tasks(stk_kernel_t *k, stk_task_t **tasks, size_t ma
     STK_ASSERT(k != nullptr);
     STK_ASSERT(tasks != nullptr);
 
-    // Collect ITask* pointers from the kernel, then map each back to stk_task_t*.
-    // TaskWrapper is the first member of stk_task_t, so ITask* == stk_task_t*.
     stk::ITask *itasks[STK_C_TASKS_MAX] = {};
-    size_t n = reinterpret_cast<IKernel *>(k)->EnumerateTasks(
-        itasks, (max_count < STK_C_TASKS_MAX ? max_count : STK_C_TASKS_MAX));
+    
+    // Determine the safe upper bound for the temporary buffer
+    const size_t requested_size = (max_count < static_cast<size_t>(STK_C_TASKS_MAX)) ? max_count : 
+        static_cast<size_t>(STK_C_TASKS_MAX);
 
-    for (size_t i = 0; i < n; ++i)
-        tasks[i] = reinterpret_cast<stk_task_t *>(itasks[i]);
+    // Pass via ArrayView temporary object
+    const size_t ret_count = reinterpret_cast<IKernel *>(k)->EnumerateTasks(
+        ArrayView<stk::ITask*>(itasks, requested_size));
 
-    return n;
+    ArrayView<stk_task_t *> output_view(tasks, max_count);
+    for (size_t i = 0U; i < ret_count; ++i)
+    {
+        output_view[i] = reinterpret_cast<stk_task_t *>(itasks[i]);
+    }
+
+    return ret_count;
 }
 
 stk_timeout_t stk_kernel_suspend(stk_kernel_t *k)
@@ -549,7 +563,7 @@ void stk_task_destroy(stk_task_t *task)
 // -----------------------------------------------------------------------------
 stk_tid_t   stk_tid(void)                      { return stk::GetTid(); }
 stk_tick_t  stk_ticks(void)                    { return stk::GetTicks(); }
-int32_t     stk_tick_resolution(void)          { return stk::GetTickResolution(); }
+uint32_t    stk_tick_resolution(void)          { return stk::GetTickResolution(); }
 stk_time_t  stk_time_now_ms(void)              { return stk::GetTimeNowMs(); }
 stk_tick_t  stk_ticks_from_ms(stk_time_t msec) { return stk_ticks_from_ms_r(msec, stk::GetTickResolution()); }
 stk_cycle_t stk_sys_timer_count(void)          { return stk::GetSysTimerCount(); }

--- a/interop/c/src/stk_c_memory.cpp
+++ b/interop/c/src/stk_c_memory.cpp
@@ -34,7 +34,7 @@ static_assert(
 // Returns a size of memory in stk::Word elements required for object allocation.
 template <typename T> static constexpr size_t StkGetWordCountForType()
 {
-    return ((sizeof(T) + sizeof(stk::Word) - 1) / sizeof(stk::Word));
+    return ((sizeof(T) + sizeof(stk::Word) - 1U) / sizeof(stk::Word));
 }
 
 // Private memory allocators (we define malloc, free here to overcome absence of declaration in
@@ -92,18 +92,22 @@ s_BlockPools[STK_C_BLOCKPOOL_MAX];
 // Find the slot that owns 'pool'; returns nullptr if not found.
 static BlockPoolSlot *FindSlot(const stk_blockpool_t *pool)
 {
-    for (uint32_t i = 0; i < STK_C_BLOCKPOOL_MAX; ++i)
+    for (size_t i = 0U; i < STK_C_BLOCKPOOL_MAX; ++i)
     {
-        if (s_BlockPools[i].busy && (s_BlockPools[i].pool() == pool))
-            return &s_BlockPools[i];
+        if (s_BlockPools[i].busy)
+        {
+            if (s_BlockPools[i].pool() == pool)
+                return &s_BlockPools[i];
+        }
     }
+    
     return nullptr;
 }
 
 // Acquire a free slot; returns nullptr when the pool is exhausted.
 static BlockPoolSlot *AcquireSlot()
 {
-    for (uint32_t i = 0; i < STK_C_BLOCKPOOL_MAX; ++i)
+    for (size_t i = 0U; i < STK_C_BLOCKPOOL_MAX; ++i)
     {
         if (!s_BlockPools[i].busy)
         {
@@ -111,6 +115,7 @@ static BlockPoolSlot *AcquireSlot()
             return &s_BlockPools[i];
         }
     }
+    
     return nullptr;
 }
 
@@ -128,7 +133,7 @@ stk_blockpool_t *stk_blockpool_create(size_t capacity, size_t raw_block_size, co
     STK_ASSERT(capacity > 0U);
     STK_ASSERT(raw_block_size > 0U);
 
-    sync::ScopedCriticalSection __cs;
+    const sync::ScopedCriticalSection cs_;
 
     BlockPoolSlot *slot = AcquireSlot();
     if (slot == nullptr)
@@ -152,7 +157,7 @@ stk_blockpool_t *stk_blockpool_create_static(size_t      capacity,
     STK_ASSERT(storage != nullptr);
     STK_ASSERT(storage_size >= (capacity * BlockMemoryPool::AlignBlockSize(raw_block_size)));
 
-    sync::ScopedCriticalSection __cs;
+    sync::ScopedCriticalSection cs_;
 
     BlockPoolSlot *slot = AcquireSlot();
     if (slot == nullptr)
@@ -170,7 +175,7 @@ void stk_blockpool_destroy(stk_blockpool_t *pool)
 {
     STK_ASSERT(pool != nullptr);
 
-    sync::ScopedCriticalSection __cs;
+    sync::ScopedCriticalSection cs_;
 
     BlockPoolSlot *slot = FindSlot(pool);
 

--- a/interop/cmsis/rtos2/src/cmsis_os2_stk.cpp
+++ b/interop/cmsis/rtos2/src/cmsis_os2_stk.cpp
@@ -179,7 +179,7 @@ struct StkThread final : public stk::ITask
     }
 
     // ---- IStackMemory ----
-    stk::Word *GetStack()            const override { return m_stack; }
+    const stk::Word *GetStack()      const override { return m_stack; }
     size_t GetStackSize()            const override { return m_stack_size; }
     size_t GetStackSizeBytes()       const override { return m_stack_size * sizeof(stk::Word); }
 
@@ -510,11 +510,11 @@ osKernelState_t osKernelGetState(void)
 
     switch (g_StkKernel.GetState())
     {
-    case stk::IKernel::STATE_INACTIVE:  return osKernelInactive;
-    case stk::IKernel::STATE_READY:     return osKernelReady;
-    case stk::IKernel::STATE_RUNNING:   return osKernelRunning;
-    case stk::IKernel::STATE_SUSPENDED: return osKernelSuspended;
-    default:                            return osKernelError;
+    case stk::IKernel::KSTATE_INACTIVE:  return osKernelInactive;
+    case stk::IKernel::KSTATE_READY:     return osKernelReady;
+    case stk::IKernel::KSTATE_RUNNING:   return osKernelRunning;
+    case stk::IKernel::KSTATE_SUSPENDED: return osKernelSuspended;
+    default:                             return osKernelError;
     }
 }
 
@@ -959,13 +959,24 @@ uint32_t osThreadGetCount(void)
 
 uint32_t osThreadEnumerate(osThreadId_t *thread_array, uint32_t array_items)
 {
-    if (osKernelGetState() == osKernelInactive)
-        return 0U;
+    uint32_t result_count = 0U;
+    const osKernelState_t kstate = osKernelGetState();
 
-    // osThreadId_t maps directly to stk::ITask (see StkThread)
-    return g_StkKernel.EnumerateTasks(reinterpret_cast<stk::ITask **>(thread_array), array_items);
+    // kernel must be active and buffer must be valid
+    if ((kstate != osKernelInactive) && (thread_array != nullptr) && (array_items != 0U))
+    {
+        // cast the raw pointer array to the expected ITask* destination type
+        stk::ITask **tasks_destination = reinterpret_cast<stk::ITask **>(thread_array);
+
+        // bind raw destination buffer into a temporary ArrayView object
+        const size_t count = g_StkKernel.EnumerateTasks(
+            stk::ArrayView<stk::ITask *>(tasks_destination, static_cast<size_t>(array_items)));
+
+        result_count = static_cast<uint32_t>(count);
+    }
+
+    return result_count;
 }
-
 
 // ===========================================================================
 // ==== Thread Flags Functions ====

--- a/interop/freertos/src/freertos_stk.cpp
+++ b/interop/freertos/src/freertos_stk.cpp
@@ -417,7 +417,7 @@ struct FrtosTask : public stk::ITask
         m_state = State::Deleted;
     }
 
-    stk::Word  *GetStack()           const override { return m_stack; }
+    const stk::Word  *GetStack()     const override { return m_stack; }
     size_t      GetStackSize()       const override { return m_stack_size; }
     size_t      GetStackSizeBytes()  const override { return m_stack_size * sizeof(stk::Word); }
     stk::EAccessMode GetAccessMode() const override { return stk::ACCESS_PRIVILEGED; }
@@ -432,16 +432,16 @@ struct FrtosTask : public stk::ITask
     size_t GetStackHighWaterMark() const { return GetStackSpace(); }
 
     // ---- Members ----
-    TaskFunction_t          m_func;
-    void                   *m_argument;
-    const char             *m_name;
-    volatile int32_t        m_weight;       // STK SWRR weight (priority+1)
-    stk::Word              *m_stack;
-    size_t                  m_stack_size;   // Words
-    bool                    m_stack_owned;
-    bool                    m_cb_owned;     // true -> heap-alloc, delete on removal
-    volatile State          m_state;
-    uint32_t                m_task_number;  // monotonic serial, assigned at construction
+    TaskFunction_t    m_func;
+    void             *m_argument;
+    const char       *m_name;
+    volatile int32_t  m_weight;       // STK SWRR weight (priority+1)
+    stk::Word        *m_stack;
+    size_t            m_stack_size;   // Words
+    bool              m_stack_owned;
+    bool              m_cb_owned;     // true -> heap-alloc, delete on removal
+    volatile State    m_state;
+    uint32_t          m_task_number;  // monotonic serial, assigned at construction
 
     // Monotonic counter incremented once per FrtosTask construction.
     // Stored as a file-scope static so all tasks share a single sequence.
@@ -1030,8 +1030,10 @@ struct FrtosMessageBuffer
 // Ensure kernel is initialized.
 static void EnsureKernelInitialized()
 {
-    if (g_StkKernel.GetState() == stk::IKernel::STATE_INACTIVE)
+    if (g_StkKernel.GetState() == stk::IKernel::KSTATE_INACTIVE)
+    {
         g_StkKernel.Initialize(); // default 1 ms tick resolution
+    }
 }
 
 // ===========================================================================
@@ -1091,9 +1093,9 @@ BaseType_t xTaskGetSchedulerState(void)
     //   STATE_SUSPENDED             -> SUSPENDED
     switch (g_StkKernel.GetState())
     {
-    case stk::IKernel::STATE_RUNNING:   return taskSCHEDULER_RUNNING;
-    case stk::IKernel::STATE_SUSPENDED: return taskSCHEDULER_SUSPENDED;
-    default:                            return taskSCHEDULER_NOT_STARTED;
+    case stk::IKernel::KSTATE_RUNNING:   return taskSCHEDULER_RUNNING;
+    case stk::IKernel::KSTATE_SUSPENDED: return taskSCHEDULER_SUSPENDED;
+    default:                             return taskSCHEDULER_NOT_STARTED;
     }
 }
 

--- a/stk/include/arch/arm/cortex-m/stk_arch_arm-cortex-m.h
+++ b/stk/include/arch/arm/cortex-m/stk_arch_arm-cortex-m.h
@@ -27,7 +27,7 @@ public:
     /*! \brief Destructor.
         \note  MISRA deviation: [STK-DEV-005] Rule 10-3-2.
     */
-    ~PlatformArmCortexM() = default;
+    STK_VIRT_DTOR ~PlatformArmCortexM() = default;
 
     void Initialize(IEventHandler *event_handler, IKernelService *service, uint32_t resolution_us, Stack *exit_trap) override;
     void Start() override;
@@ -104,7 +104,7 @@ __stk_forceinline void SetTls(Word tp)
 /*! \def   __stk_dmb
     \brief Hardware memory barrier: ensures visibility across cores and bus masters.
 */
-#define __stk_dmb() __asm volatile("dmb sy" ::: "memory")
+static __stk_forceinline void __stk_dmb() { __asm volatile("dmb sy" ::: "memory"); }
 
 /*! \def   __stk_tz_nsc_entry
     \brief TrustZone: attribute for Non-Secure callable gateway functions.

--- a/stk/include/arch/risc-v/stk_arch_risc-v.h
+++ b/stk/include/arch/risc-v/stk_arch_risc-v.h
@@ -101,7 +101,7 @@ __stk_forceinline void SetTls(Word tp)
 /*! \def   __stk_dmb
     \brief Data memory barrier.
 */
-#define __stk_dmb() __asm volatile("fence rw, rw" ::: "memory")
+static __stk_forceinline void __stk_dmb() { __asm volatile("fence rw, rw" ::: "memory"); }
 
 /*! \def   STK_SUBMICORSECOND_PRECISION_TIMER
     \brief Enables sub-microsecond precision timer, see \a hw::HiResClock.

--- a/stk/include/arch/stk_arch_common.h
+++ b/stk/include/arch/stk_arch_common.h
@@ -31,7 +31,7 @@ public:
     /*! \brief Destructor.
         \note  MISRA deviation: [STK-DEV-005] Rule 10-3-2.
     */
-    ~PlatformContext() = default;
+    STK_VIRT_DTOR ~PlatformContext() = default;
 
     /*! \brief     Initialize context.
         \param[in] handler: Event handler.
@@ -51,24 +51,26 @@ public:
     /*! \brief     Initialize stack memory by filling it with STK_STACK_MEMORY_FILLER.
         \note      Returned pointer is for a stack growing from top to down.
         \param[in] memory: Stack memory to initialize.
-        \return    Pointer to initialized stack memory.
+        \return    Top of the stack memory (valid memory region is (stack_top - sizeof(Word))).
     */
-    static inline Word *InitStackMemory(IStackMemory *memory)
+    static inline Word InitStackMemory(IStackMemory *const memory)
     {
-        const size_t stack_size = memory->GetStackSize();
-        Word *itr = const_cast<Word *>(memory->GetStack());
-        Word *const stack_top = itr + stack_size;
-
-        STK_ASSERT(stack_size >= STACK_SIZE_MIN);
-
-        // initialization of the stack memory satisfies stack integrity check in Kernel::StateSwitch
-        while (itr < stack_top)
+        STK_ASSERT(memory != nullptr);
+              
+        ArrayView<Word> stack(const_cast<Word *>(memory->GetStack()), memory->GetStackSize());
+        STK_ASSERT(stack.GetSize() >= STACK_SIZE_MIN);
+        
+        // initialize stack memory to satisfy stack integrity check in Kernel::StateSwitch
+        for (size_t i = 0U; i < stack.GetSize(); ++i)
         {
-            *itr++ = STK_STACK_MEMORY_FILLER;
+            stack[i] = STK_STACK_MEMORY_FILLER;
         }
+        
+        // get address of the last valid item and step forward by 1 Word size
+        const Word stack_top = hw::PtrToWord(memory->GetStack()) + (stack.GetSize() * sizeof(Word));
 
         // expecting STK_STACK_MEMORY_ALIGN-byte aligned memory for a stack
-        STK_ASSERT((hw::PtrToWord(stack_top) & (STK_STACK_MEMORY_ALIGN - 1)) == 0U);
+        STK_ASSERT((stack_top & (STK_STACK_MEMORY_ALIGN - 1U)) == 0U);
 
         return stack_top;
     }
@@ -102,9 +104,9 @@ protected:
     \param[in] time_us: Time (microseconds).
     \return    Clock cycles.
 */
-static __stk_forceinline Cycles ConvertTimeUsToClockCycles(Cycles clock_freq, Ticks time_us)
+static __stk_forceinline Cycles ConvertTimeUsToClockCycles(uint32_t clock_freq, Ticks time_us)
 {
-    return ((clock_freq * static_cast<Cycles>(time_us)) / 1000000ULL);
+    return ((static_cast<Cycles>(time_us) * clock_freq) / 1000000ULL);
 }
 
 } // namespace stk

--- a/stk/include/arch/x86/win32/stk_arch_x86-win32.h
+++ b/stk/include/arch/x86/win32/stk_arch_x86-win32.h
@@ -65,13 +65,13 @@ typedef PlatformX86Win32 PlatformDefault;
     #include <intrin.h>
     #if defined(_M_IX86) || defined(_M_X64)
         // x86/x64: full hardware serializing fence
-        #define __stk_dmb() _mm_mfence()
+        static __stk_forceinline void __stk_dmb() { _mm_mfence(); }
     #elif defined(_M_ARM) || defined(_M_ARM64)
         // ARM/ARM64: Data Memory Barrier (Inner Shareable)
-        #define __stk_dmb() __dmb(_ARM_BARRIER_ISH)
+        static __stk_forceinline void __stk_dmb() { __dmb(_ARM_BARRIER_ISH); }
     #endif
 #elif defined(__GNUC__) || defined(__clang__)
-    #define __stk_dmb() __sync_synchronize()
+    static __stk_forceinline void __stk_dmb() { __sync_synchronize(); }
 #else
     #error "__stk_dmb() is not implemented for this compiler."
 #endif

--- a/stk/include/memory/stk_memory_allocator.h
+++ b/stk/include/memory/stk_memory_allocator.h
@@ -65,7 +65,8 @@ struct MemoryAllocator
     struct Stats
     {
         Stats(size_t _capacity = CAPACITY_DEFAULT)
-            : capacity(_capacity), allocated(0U), allocate_count(0U), free_count(0U), min_ever_free(_capacity)
+            : capacity(_capacity), allocated(0U), allocate_count(0U), free_count(0U), 
+              min_ever_free(_capacity)
         {}
 
         const size_t    capacity;       //!< Total capacity of the memory pool in bytes.
@@ -137,8 +138,11 @@ struct MemoryAllocator
         TElement *ptr = reinterpret_cast<TElement *>(Allocate(sizeof(TElement)));
         if (ptr != nullptr)
         {
-            if (!std::is_trivially_constructible<TElement, TArgs...>())
-                new (ptr) TElement(static_cast<TArgs &&>(args)...);
+            if __stk_constexpr_cpp17 (!std::is_trivially_constructible<TElement, TArgs...>())
+            {
+                auto const elm = new (ptr) TElement(static_cast<TArgs &&>(args)...);
+                STK_UNUSED(elm);
+            }
         }
 
         return ptr;
@@ -153,18 +157,23 @@ struct MemoryAllocator
     template <typename TElement, typename... TArgs>
     static inline TElement *AllocateArrayT(size_t count, TArgs &&...args)
     {
-        if (count == 0)
-            return nullptr;
-
-        STK_ASSERT(Allocate != nullptr);
-
-        TElement *ptr = reinterpret_cast<TElement *>(Allocate(count * sizeof(TElement)));
-        if (ptr != nullptr)
+        TElement *ptr = nullptr;
+      
+        if (count != 0U)
         {
-            if (!std::is_trivially_constructible<TElement, TArgs...>())
+            STK_ASSERT(Allocate != nullptr);
+
+            ptr = reinterpret_cast<TElement *>(Allocate(count * sizeof(TElement)));
+            if (ptr != nullptr)
             {
-                for (size_t i = 0; i < count; ++i)
-                    new (&ptr[i]) TElement(static_cast<TArgs &&>(args)...);
+                if __stk_constexpr_cpp17 (!std::is_trivially_constructible<TElement, TArgs...>())
+                {
+                    for (size_t i = 0U; i < count; ++i)
+                    {
+                        auto const elm = new (&ptr[i]) TElement(static_cast<TArgs &&>(args)...);
+                        STK_UNUSED(elm);
+                    }
+                }
             }
         }
 
@@ -181,8 +190,10 @@ struct MemoryAllocator
 
         if (ptr != nullptr)
         {
-            if (!std::is_trivially_destructible<TElement>())
+            if __stk_constexpr_cpp17 (!std::is_trivially_destructible<TElement>())
+            {
                 ptr->~TElement();
+            }
 
             Free(ptr);
         }
@@ -199,11 +210,17 @@ struct MemoryAllocator
 
         if (ptr != nullptr)
         {
-            if (!std::is_trivially_destructible<TElement>())
+            if __stk_constexpr_cpp17 (!std::is_trivially_destructible<TElement>())
             {
                 // destroy in reverse order (mirrors stack unwinding)
-                for (size_t i = count; i > 0; --i)
+                for (size_t i = count; i > 0U; --i)
+                {
                     ptr[i - 1].~TElement();
+                }
+            }
+            else
+            {
+                STK_UNUSED(count);
             }
 
             Free(ptr);

--- a/stk/include/memory/stk_memory_blockpool.h
+++ b/stk/include/memory/stk_memory_blockpool.h
@@ -143,7 +143,7 @@ public:
                    is triggered in debug builds inside the \c ConditionVariable destructor.
         \note      MISRA deviation: [STK-DEV-005] Rule 10-3-2.
     */
-    ~BlockMemoryPool();
+    STK_VIRT_DTOR ~BlockMemoryPool();
 
     /*! \brief     Round a raw block size up to the nearest multiple of \c BLOCK_ALIGN.
         \details   Enforces a minimum of \c BLOCK_ALIGN so the free-list link always
@@ -164,24 +164,24 @@ public:
         \details   If the pool is empty the calling task is suspended via the internal
                    \c ConditionVariable and woken by the next \c Free() call. On return the
                    caller owns the block and must eventually return it via \c Free().
-        \param[in] timeout: Maximum time to wait (ticks).
+        \param[in] timeout_ticks: Maximum time to wait (ticks).
                    \c WAIT_INFINITE - block indefinitely (default).
                    \c NO_WAIT       - return \c nullptr immediately if pool is empty
                                       (identical to \c TryAlloc(); ISR-safe).
         \return    Pointer to an uninitialized block of at least \c GetRawBlockSize() bytes,
                    or \c nullptr if the timeout expired before a block became available.
-        \warning   ISR-safe \b only when \a timeout = \c NO_WAIT; ISR-unsafe otherwise.
+        \warning   ISR-safe \b only when \a timeout_ticks = \c NO_WAIT; ISR-unsafe otherwise.
     */
-    void *TimedAlloc(Timeout timeout = WAIT_INFINITE);
+    void *TimedAlloc(Timeout timeout_ticks = WAIT_INFINITE);
 
     /*! \brief     Allocate one typed block, blocking until one becomes available or the timeout expires.
         \details   Thin typed wrapper around \c TimedAlloc(). Asserts that \c sizeof(T) fits
                    within the aligned block size chosen at construction.
-        \param[in] timeout: Maximum time to wait (ticks). Same semantics as \c TimedAlloc().
+        \param[in] timeout_ticks: Maximum time to wait (ticks). Same semantics as \c TimedAlloc().
         \return    Typed pointer, or \c nullptr if the timeout expired.
-        \warning   ISR-safe \b only when \a timeout = \c NO_WAIT; ISR-unsafe otherwise.
+        \warning   ISR-safe \b only when \a timeout_ticks = \c NO_WAIT; ISR-unsafe otherwise.
     */
-    template <typename T> T *TimedAllocT(Timeout timeout = WAIT_INFINITE);
+    template <typename T> T *TimedAllocT(Timeout timeout_ticks = WAIT_INFINITE);
 
     /*! \brief     Allocate one block, blocking indefinitely until one is available.
         \return    Pointer to an uninitialized block. Never returns \c nullptr.
@@ -316,7 +316,7 @@ private:
     sync::ConditionVariable  m_cv;             //!< signalled by Free() to wake one task blocked in TimedAlloc()
     size_t                   m_block_size;     //!< aligned block size in bytes (>= BLOCK_ALIGN)
     size_t                   m_capacity;       //!< total number of blocks
-    uint16_t                 m_used_count;     //!< number of blocks currently allocated (outstanding)
+    size_t                   m_used_count;     //!< number of blocks currently allocated (outstanding)
     bool                     m_storage_owned;  //!< true -> storage is heap-allocated; free in destructor
 };
 
@@ -343,7 +343,9 @@ inline BlockMemoryPool::BlockMemoryPool(size_t capacity, size_t raw_block_size, 
 
     // in Release builds we ensure capacity which fits storage size, in Debug build the assertion above will be hit
     if ((capacity * m_block_size) > storage_size)
+    {
         m_capacity = storage_size / m_block_size;
+    }
 
 #if STK_SYNC_DEBUG_NAMES
     SetTraceName(name);
@@ -374,7 +376,9 @@ inline BlockMemoryPool::BlockMemoryPool(size_t capacity, size_t raw_block_size, 
 #endif
 
     if (m_storage != nullptr)
+    {
         BuildFreeList();
+    }
     // else: m_free_list remains nullptr; caller must check IsStorageValid()
 }
 #endif
@@ -395,33 +399,46 @@ inline BlockMemoryPool::~BlockMemoryPool()
 // Alloc / TimedAlloc / TryAlloc
 // ---------------------------------------------------------------------------
 
-inline void *BlockMemoryPool::TimedAlloc(Timeout timeout)
+inline void *BlockMemoryPool::TimedAlloc(Timeout timeout_ticks)
 {
-    if (hw::IsInsideISR() && (timeout != NO_WAIT))
+    void *block = nullptr;
+  
+    if (!hw::IsInsideISR() || (timeout_ticks == NO_WAIT))
+    {
+        sync::ScopedCriticalSection cs_;
+        bool is_timeout = false;
+
+        while (m_free_list == nullptr)
+        {
+            // Atomically release the critical section, suspend the task, and
+            // re-acquire before returning - no CPU cycles wasted while waiting.
+            if (!m_cv.Wait(cs_, timeout_ticks))
+            {
+                is_timeout = true; // timeout expired
+                break;
+            }
+        }
+
+        // only allocate a block if we didn't time out
+        if (!is_timeout)
+        {
+            block = PopFreeList();
+        }
+    }
+    else
     {
         STK_ASSERT(false); // API contract: ISR callers must pass NO_WAIT / use TryAlloc()
-        return nullptr;
     }
 
-    sync::ScopedCriticalSection cs_;
-
-    while (m_free_list == nullptr)
-    {
-        // Atomically release the critical section, suspend the task, and
-        // re-acquire before returning - no CPU cycles wasted while waiting.
-        if (!m_cv.Wait(cs_, timeout))
-            return nullptr; // timeout expired
-    }
-
-    return PopFreeList();
+    return block;
 }
 
 template <typename T>
-inline T *BlockMemoryPool::TimedAllocT(Timeout timeout)
+inline T *BlockMemoryPool::TimedAllocT(Timeout timeout_ticks)
 {
     STK_ASSERT(sizeof(T) <= m_block_size); // API contract: block size should larger or equal to object's size
 
-    return static_cast<T *>(TimedAlloc(timeout));
+    return static_cast<T *>(TimedAlloc(timeout_ticks));
 }
 
 inline void *BlockMemoryPool::Alloc()
@@ -452,58 +469,68 @@ inline T *BlockMemoryPool::TryAllocT()
 
 inline bool BlockMemoryPool::Free(void *ptr)
 {
-    if (ptr == nullptr)
-        return false;
+    bool success = false;
 
-    // bounds check: ptr must be in range [m_storage, m_storage + capacity * block_size)
-    const uint8_t *p8 = static_cast<uint8_t *>(ptr);
-    const uint8_t *lo = m_storage;
-    const uint8_t *hi = m_storage + (m_capacity * m_block_size);
-
-    if ((p8 < lo) || (p8 >= hi))
+    if (ptr != nullptr)
     {
-        STK_ASSERT(false); // API contract: ptr does not belong to this pool
-        return false;
-    }
+        // bounds check: ptr must be in range [m_storage, m_storage + capacity * block_size)
+        const Word pt = hw::PtrToWord(ptr);
+        const Word lo = hw::PtrToWord(m_storage);
+        const Word hi = lo + (m_capacity * m_block_size);
 
-    // alignment check: ptr must be at the start of a block boundary
-    if ((static_cast<size_t>(p8 - lo) % m_block_size) != 0U)
-    {
-        STK_ASSERT(false); // API contract: ptr is misaligned (not a block start)
-        return false;
-    }
-
-    sync::ScopedCriticalSection cs_;
-
-    if (m_used_count == 0U)
-    {
-        STK_ASSERT(false); // pool is already fully free - definite double-free
-        return false;
-    }
-
-#if defined(_DEBUG) || defined(DEBUG)
-    // O(n) double-free detection: walk the free-list and check if ptr is already on it,
-    // only active in debug builds - compiles away completely in release
-    for (const MemoryBlock *node = m_free_list; (node != nullptr); node = node->next)
-    {
-        if (node == reinterpret_cast<const MemoryBlock *>(ptr))
+        if ((pt < lo) || (pt >= hi))
         {
-            STK_ASSERT(false); // double-free: ptr is already on the free-list
-            return false;
+            STK_ASSERT(false); // API contract: ptr does not belong to this pool
+        }
+        // alignment check: ptr must be at the start of a block boundary
+        else if ((static_cast<size_t>(pt - lo) % m_block_size) != 0U)
+        {
+            STK_ASSERT(false); // API contract: ptr is misaligned (not a block start)
+        }
+        else
+        {
+            const sync::ScopedCriticalSection cs_;
+
+            if (m_used_count == 0U)
+            {
+                STK_ASSERT(false); // pool is already fully free - definite double-free
+            }
+            else
+            {
+            #if defined(_DEBUG) || defined(DEBUG)
+                bool is_double_free = false;
+
+                // O(n) double-free detection: walk the free-list and check if ptr is already on it,
+                // only active in debug builds - compiles away completely in release
+                for (const MemoryBlock *node = m_free_list; (node != nullptr); node = node->next)
+                {
+                    if (node == reinterpret_cast<const MemoryBlock *>(ptr))
+                    {
+                        STK_ASSERT(false); // double-free: ptr is already on the free-list
+                        is_double_free = true;
+                        break;
+                    }
+                }
+
+                if (!is_double_free)
+            #endif
+                {
+                    // push block onto free-list head (O(1))
+                    auto *const blk = reinterpret_cast<MemoryBlock *>(ptr);
+                    blk->next       = m_free_list;
+                    m_free_list     = blk;
+                    m_used_count    = static_cast<uint16_t>(m_used_count - 1U);
+
+                    // wake one blocked allocator - true scheduler wait, no spin-yield
+                    m_cv.NotifyOne_CS();
+                    
+                    success = true;
+                }
+            }
         }
     }
-#endif
 
-    // push block onto free-list head (O(1))
-    auto *blk   = reinterpret_cast<MemoryBlock *>(ptr);
-    blk->next   = m_free_list;
-    m_free_list = blk;
-    m_used_count = static_cast<uint16_t>(m_used_count - 1U);
-
-    // wake one blocked allocator - true scheduler wait, no spin-yield
-    m_cv.NotifyOne_CS();
-
-    return true;
+    return success;
 }
 
 // ---------------------------------------------------------------------------
@@ -521,7 +548,7 @@ inline void BlockMemoryPool::BuildFreeList()
     // (lowest address), giving ascending allocation order.
     for (size_t i = m_capacity; i-- > 0U; )
     {
-        MemoryBlock *blk = reinterpret_cast<MemoryBlock *>(m_storage + (i * m_block_size));
+        MemoryBlock *const blk = reinterpret_cast<MemoryBlock *>(m_storage + (i * m_block_size));
 
         blk->next   = m_free_list;
         m_free_list = blk;
@@ -532,7 +559,7 @@ inline void *BlockMemoryPool::PopFreeList()
 {
     STK_ASSERT(m_used_count < m_capacity);
 
-    MemoryBlock *blk = m_free_list;
+    MemoryBlock *const blk = m_free_list;
 
     m_free_list  = blk->next;
     m_used_count = static_cast<uint16_t>(m_used_count + 1U);

--- a/stk/include/stk.h
+++ b/stk/include/stk.h
@@ -102,8 +102,8 @@ protected:
     */
     enum ERequest : uint8_t
     {
-        REQUEST_NONE     = 0,       //!< No pending requests.
-        REQUEST_ADD_TASK = (1 << 0) //!< An AddTask() request is pending from a running task (KERNEL_DYNAMIC only).
+        REQ_NONE     = 0,       //!< No pending requests.
+        REQ_ADD_TASK = (1 << 0) //!< An AddTask() request is pending from a running task (KERNEL_DYNAMIC only).
     };
 
     /*! \class KernelTask
@@ -153,8 +153,10 @@ protected:
             m_srt(), m_hrt(), m_rt_weight()
         {
             // bind to wait object
-            if (IsSyncMode())
+            if __stk_constexpr_cpp17 (IsSyncMode())
+            {
                 m_wait_obj->m_task = this;
+            }
         }
 
         /*! \brief  Get bound user task.
@@ -163,9 +165,9 @@ protected:
         ITask *GetUserTask() override { return m_user; }
 
         /*! \brief  Get stack descriptor for this task slot.
-            \return Pointer to the Stack (SP register value and access mode flags).
+            \return Stack info (SP register value and access mode flags).
         */
-        Stack *GetUserStack() override { return &m_stack; }
+        Stack GetUserStack() const { return m_stack;}
 
         /*! \brief  Check whether this slot is bound to a user task.
             \return \c true if a user task is assigned (m_user != NULL); \c false if the slot is free.
@@ -199,8 +201,10 @@ protected:
         */
         void SetCurrentWeight(Weight weight) override
         {
-            if (TStrategy::WEIGHT_API)
+            if __stk_constexpr_cpp17 (TStrategy::WEIGHT_API)
+            {
                 m_rt_weight[0] = weight;
+            }
         }
 
         /*! \brief  Get static scheduling weight from the user task.
@@ -208,13 +212,22 @@ protected:
         */
         Weight GetWeight() const override
         {
-            if (TStrategy::PRIORITY_INHERITANCE_API)
+            if __stk_constexpr_cpp17 (TStrategy::PRIORITY_INHERITANCE_API)
             {
                 if (m_rt_weight[0] != NO_WEIGHT)
+                {
                     return m_rt_weight[0];
+                }
             }
-
-            return (TStrategy::WEIGHT_API ? m_user->GetWeight() : DEFAULT_WEIGHT);
+            
+            if __stk_constexpr_cpp17 (TStrategy::WEIGHT_API)
+            {
+                return m_user->GetWeight();
+            }
+            else
+            {
+                return DEFAULT_WEIGHT;
+            }
         }
 
         /*! \brief  Get current (run-time) scheduling weight.
@@ -224,7 +237,14 @@ protected:
         */
         Weight GetCurrentWeight() const override
         {
-            return (TStrategy::WEIGHT_API ? m_rt_weight[0] : DEFAULT_WEIGHT);
+            if __stk_constexpr_cpp17 (TStrategy::WEIGHT_API)
+            {
+                return m_rt_weight[0];
+            }
+            else
+            {
+                return DEFAULT_WEIGHT;
+            }
         }
 
         /*! \brief  Get HRT scheduling periodicity.
@@ -234,8 +254,15 @@ protected:
         Timeout GetHrtPeriodicity() const override
         {
             STK_ASSERT(IsHrtMode());
-
-            return (IsHrtMode() ? m_hrt[0].periodicity : 0);
+            
+            if __stk_constexpr_cpp17 (IsHrtMode())
+            {
+                return m_hrt[0].periodicity;
+            }
+            else
+            {
+                return 0;
+            }
         }
 
         /*! \brief  Get absolute HRT deadline (ticks elapsed since task was activated).
@@ -247,7 +274,14 @@ protected:
         {
             STK_ASSERT(IsHrtMode());
 
-            return (IsHrtMode() ? m_hrt[0].deadline : 0);
+            if __stk_constexpr_cpp17 (IsHrtMode())
+            {
+                return m_hrt[0].deadline;
+            }
+            else
+            {
+                return 0;
+            }
         }
 
         /*! \brief  Get remaining HRT deadline (ticks left before the deadline expires).
@@ -260,7 +294,14 @@ protected:
             STK_ASSERT(IsHrtMode());
             STK_ASSERT(!IsSleeping());
 
-            return (IsHrtMode() ? (m_hrt[0].deadline - m_hrt[0].duration) : 0);
+            if __stk_constexpr_cpp17 (IsHrtMode())
+            {
+                return (m_hrt[0].deadline - m_hrt[0].duration);
+            }
+            else
+            {
+                return 0;
+            }
         }
 
         Timeout GetSleepTicks(Timeout sleep_ticks)
@@ -268,7 +309,7 @@ protected:
             // note: task sleep time is negative
             Timeout task_sleep = Max<Timeout>(NO_WAIT, -m_time_sleep);
 
-            if (IsSyncMode())
+            if __stk_constexpr_cpp17 (IsSyncMode())
             {
                 // likely task is sleeping during sync operation (see Wait)
                 if (m_wait_obj->IsWaiting())
@@ -278,7 +319,9 @@ protected:
 
                     // we shall account for only valid time (when task is waiting during sync operation)
                     if (task_sleep > NO_WAIT)
+                    {
                         sleep_ticks = Min(sleep_ticks, task_sleep);
+                    }
                 }
                 else
                 {
@@ -298,8 +341,7 @@ protected:
         /*! \brief Destructor.
             \note  MISRA deviation: [STK-DEV-005] Rule 10-3-2.
         */
-        ~KernelTask()
-        {}
+        STK_VIRT_DTOR ~KernelTask() = default;
 
         /*! \class SrtInfo
             \brief Per-task soft real-time (SRT) metadata.
@@ -365,8 +407,7 @@ protected:
             /*! \brief Destructor.
                 \note  MISRA deviation: [STK-DEV-005] Rule 10-3-2.
             */
-            ~WaitObject()
-            {}
+            STK_VIRT_DTOR ~WaitObject() = default;
 
             /*! \class WaitRequest
                 \brief Payload stored in the sync object's kernel-side list entry while a task is waiting.
@@ -419,12 +460,17 @@ protected:
             */
             bool Tick(Timeout elapsed_ticks) override
             {
-                if ((m_time_wait != WAIT_INFINITE) && !m_timeout)
+                if (m_time_wait != WAIT_INFINITE)
                 {
-                    m_time_wait -= elapsed_ticks;
+                    if (!m_timeout)
+                    {                  
+                        m_time_wait -= elapsed_ticks;
 
-                    if (m_time_wait <= 0)
-                        m_timeout = true;
+                        if (m_time_wait <= 0)
+                        {
+                            m_timeout = true;
+                        }
+                    }
                 }
 
                 return !m_timeout;
@@ -461,7 +507,7 @@ protected:
         void Bind(TPlatform *platform, ITask *user_task)
         {
             // set access mode for this stack
-            m_stack.mode = user_task->GetAccessMode();
+            m_stack.access_mode = user_task->GetAccessMode();
 
             // set task id for tracking purpose
         #if STK_NEED_TASK_ID
@@ -478,8 +524,10 @@ protected:
             m_user = user_task;
 
             // initialize current weight to NO_WEIGHT for priority inheritance mechanism
-            if (TStrategy::PRIORITY_INHERITANCE_API)
+            if __stk_constexpr_cpp17 (TStrategy::PRIORITY_INHERITANCE_API)
+            {
                 SetCurrentWeight(NO_WEIGHT);
+            }
         }
 
         /*! \brief Reset this slot to the free (unbound) state, clearing all scheduling metadata.
@@ -487,7 +535,7 @@ protected:
         */
         void Unbind()
         {
-            if (IsSyncMode())
+            if __stk_constexpr_cpp17 (IsSyncMode())
             {
                 // should be freed from waiting on task exit
                 STK_ASSERT(!m_wait_obj->IsWaiting());
@@ -498,10 +546,14 @@ protected:
             m_state      = STATE_NONE;
             m_time_sleep = 0;
 
-            if (IsHrtMode())
+            if __stk_constexpr_cpp17 (IsHrtMode())
+            {
                 m_hrt[0].Clear();
+            }
             else
+            {
                 m_srt->Clear();
+            }
         }
 
         /*! \brief     Schedule the removal of the task from the kernel on next tick.
@@ -512,8 +564,10 @@ protected:
             ScheduleSleep(WAIT_INFINITE);
 
             // mark it as done HRT task
-            if (IsHrtMode())
+            if __stk_constexpr_cpp17 (IsHrtMode())
+            {
                 HrtOnWorkCompleted();
+            }
 
             // mark it as pending for removal
             m_state |= STATE_REMOVE_PENDING;
@@ -528,10 +582,10 @@ protected:
         */
         bool IsMemoryOfSP(Word SP) const
         {
-            const Word *const start = m_user->GetStack();
-            const Word *const end   = start + m_user->GetStackSize();
+            const Word start = hw::PtrToWord(m_user->GetStack());
+            const Word end   = start + (m_user->GetStackSize() * sizeof(Word));
 
-            return (SP >= hw::PtrToWord(start)) && (SP <= hw::PtrToWord(end));
+            return (SP >= start) && (SP <= end);
         }
 
         /*! \brief     Initialize task with HRT info.
@@ -552,7 +606,9 @@ protected:
             m_hrt[0].deadline    = deadline_tc;
 
             if (start_delay_tc > 0)
+            {
                 ScheduleSleep(start_delay_tc);
+            }
         }
 
         /*! \brief     Called when task is switched into the scheduling process.
@@ -570,9 +626,11 @@ protected:
 
             STK_ASSERT(duration >= 0);
 
-            Timeout sleep = m_hrt[0].periodicity - duration;
+            const Timeout sleep = m_hrt[0].periodicity - duration;
             if (sleep > 0)
+            {
                 ScheduleSleep(sleep);
+            }
 
             m_hrt[0].duration = 0;
             m_hrt[0].done     = false;
@@ -624,10 +682,12 @@ protected:
             STK_ASSERT(ticks > 0);
 
             // set state first as kernel checks it when task IsSleeping
-            if (TStrategy::SLEEP_EVENT_API)
+            if __stk_constexpr_cpp17 (TStrategy::SLEEP_EVENT_API)
             {
                 if (!IsSleeping())
+                {
                     m_state |= STATE_SLEEP_PENDING;
+                }
             }
 
             m_time_sleep = -ticks;
@@ -643,6 +703,11 @@ protected:
                 __stk_relax_cpu();
             }
         }
+        
+        /*! \brief  Get pointer to user Stack.
+            \return Pointer to the Stack (SP register value and access mode flags).
+        */
+        Stack *GetUserStackPtr() { return &m_stack; }
 
         ITask            *m_user;       //!< Bound user task, or \c NULL when slot is free.
         Stack             m_stack;      //!< Stack descriptor (SP register value + access mode + optional tid).
@@ -696,7 +761,7 @@ protected:
             STK_ASSERT(!hw::IsInsideISR());
             STK_ASSERT(ticks >= 0);
 
-            if (!IsHrtMode())
+            if __stk_constexpr_cpp17 (!IsHrtMode())
             {
                 m_kernel->m_platform.Sleep(ticks);
             }
@@ -711,7 +776,7 @@ protected:
         {
             STK_ASSERT(!hw::IsInsideISR());
 
-            if (!IsHrtMode())
+            if __stk_constexpr_cpp17 (!IsHrtMode())
             {
                 return m_kernel->m_platform.SleepUntil(timestamp);
             }
@@ -725,7 +790,7 @@ protected:
 
         void SleepCancel(TId task_id) override
         {
-            if (!IsHrtMode())
+            if __stk_constexpr_cpp17 (!IsHrtMode())
             {
                 m_kernel->OnTaskSleepCancel(task_id);
             }
@@ -740,7 +805,7 @@ protected:
 
         IWaitObject *Wait(ISyncObject *sobj, IMutex *mutex, Timeout ticks) override
         {
-            if (IsSyncMode())
+            if __stk_constexpr_cpp17 (IsSyncMode())
             {
                 return m_kernel->m_platform.Wait(sobj, mutex, ticks);
             }
@@ -753,7 +818,7 @@ protected:
 
         Timeout Suspend() override
         {
-            if (IsTicklessMode())
+            if __stk_constexpr_cpp17 (IsTicklessMode())
             {
                 return m_kernel->m_platform.Suspend();
             }
@@ -766,7 +831,7 @@ protected:
 
         void Resume(Timeout elapsed_ticks) override
         {
-            if (IsTicklessMode())
+            if __stk_constexpr_cpp17 (IsTicklessMode())
             {
                 return m_kernel->m_platform.Resume(elapsed_ticks);
             }
@@ -778,14 +843,18 @@ protected:
 
         void InheritWeight(TId tid, Weight weight) override
         {
-            if (TStrategy::PRIORITY_INHERITANCE_API)
+            if __stk_constexpr_cpp17 (TStrategy::PRIORITY_INHERITANCE_API)
+            {
                 m_kernel->OnInheritWeight(tid, weight);
+            }
         }
 
         void RestoreWeight(TId tid, ISyncObject *sobj) override
         {
-            if (TStrategy::PRIORITY_INHERITANCE_API)
+            if __stk_constexpr_cpp17 (TStrategy::PRIORITY_INHERITANCE_API)
+            {
                 m_kernel->OnRestoreWeight(tid, sobj);
+            }
         }
 
     private:
@@ -798,8 +867,7 @@ protected:
         /*! \brief Destructor.
             \note  MISRA deviation: [STK-DEV-005] Rule 10-3-2.
         */
-        ~KernelService()
-        {}
+        STK_VIRT_DTOR ~KernelService() = default;
 
         /*! \brief     Initialize instance.
             \note      When call completes Singleton<IKernelService *> will start referencing this
@@ -827,17 +895,17 @@ protected:
 public:
     /*! \brief Maximum number of concurrently registered tasks. Fixed at compile time. Exceeding this limit in AddTask() triggers a compile-time assert (TASKS_MAX > 0) and a runtime STK_ASSERT.
     */
-    static constexpr uint32_t TASKS_MAX = TSize;
+    static constexpr size_t TASKS_MAX = TSize;
 
     /*! \brief Construct the kernel with all storage zero-initialized and the request flag set to ~0
-               (indicating uninitialized state; cleared to REQUEST_NONE by Initialize()).
+               (indicating uninitialized state; cleared to REQ_NONE by Initialize()).
         \note  In debug builds also verifies that TPlatform derives from IPlatform and TStrategy
                from ITaskSwitchStrategy.
         \note  If TMode includes KERNEL_TICKLESS, a compile-time assertion fires unless
                STK_TICKLESS_IDLE is defined to 1 in stk_config.h.
     */
     explicit Kernel() : m_platform(), m_strategy(), m_task_now(nullptr), m_task_storage(), m_sleep_trap(),
-        m_exit_trap(), m_fsm_state(FSM_STATE_NONE), m_request(REQUEST_NONE), m_state(STATE_INACTIVE)
+        m_exit_trap(), m_fsm_state(FSM_STATE_NONE), m_request(REQ_NONE), m_kstate(KSTATE_INACTIVE)
     {
     #ifdef _DEBUG
         // TPlatform must inherit IPlatform
@@ -858,8 +926,7 @@ public:
     /*! \brief Destructor.
         \note  MISRA deviation: [STK-DEV-005] Rule 10-3-2.
     */
-    ~Kernel()
-    {}
+    STK_VIRT_DTOR ~Kernel() = default;
 
     /*! \brief     Initialize kernel.
         \param[in] resolution_us: Resolution of the system tick (SysTick) timer in microseconds.
@@ -879,14 +946,24 @@ public:
         // reinitialize key state variables
         m_task_now  = nullptr;
         m_fsm_state = FSM_STATE_NONE;
-        m_request   = REQUEST_NONE;
+        m_request   = REQ_NONE;
+        
+        // exit trap is required only for KERNEL_DYNAMIC mode
+        Stack *exit_trap = nullptr;
+        if __stk_constexpr_cpp17 (IsDynamicMode())
+        {
+            exit_trap = &m_exit_trap[0].stack;
+        }
+        else
+        {
+            STK_UNUSED(exit_trap);
+        }
 
         m_service.Initialize(this);
-
-        m_platform.Initialize(this, &m_service, resolution_us, (IsDynamicMode() ? &m_exit_trap[0].stack : nullptr));
+        m_platform.Initialize(this, &m_service, resolution_us, exit_trap);
 
         // now ready to Start()
-        m_state = STATE_READY;
+        m_kstate = KSTATE_READY;
     }
 
     /*! \brief     Register task for a soft real-time (SRT) scheduling.
@@ -899,7 +976,7 @@ public:
     */
     __stk_attr_noinline void AddTask(ITask *user_task) override
     {
-        if (!IsHrtMode())
+        if __stk_constexpr_cpp17 (!IsHrtMode())
         {
             STK_ASSERT(user_task != nullptr);
             STK_ASSERT(IsInitialized());
@@ -908,7 +985,7 @@ public:
             // kernel processes this request
             if (IsStarted())
             {
-                if (IsDynamicMode())
+                if __stk_constexpr_cpp17 (IsDynamicMode())
                 {
                     RequestAddTask(user_task);
                 }
@@ -939,7 +1016,7 @@ public:
     __stk_attr_noinline void AddTask(ITask *user_task, Timeout periodicity_tc, Timeout deadline_tc,
         Timeout start_delay_tc) override
     {
-        if (IsHrtMode())
+        if __stk_constexpr_cpp17 (IsHrtMode())
         {
             STK_ASSERT(user_task != nullptr);
             STK_ASSERT(IsInitialized());
@@ -963,14 +1040,16 @@ public:
     */
     __stk_attr_noinline void RemoveTask(ITask *user_task) override
     {
-        if (IsDynamicMode())
+        if __stk_constexpr_cpp17 (IsDynamicMode())
         {
             STK_ASSERT(user_task != nullptr);
             STK_ASSERT(!IsStarted());
 
-            KernelTask *task = FindTaskByUserTask(user_task);
+            KernelTask *const task = FindTaskByUserTask(user_task);
             if (task != nullptr)
+            {
                 RemoveTask(task);
+            }
         }
         else
         {
@@ -986,16 +1065,18 @@ public:
     */
     __stk_attr_noinline void ScheduleTaskRemoval(ITask *user_task) override
     {
-        if (IsDynamicMode())
+        if __stk_constexpr_cpp17 (IsDynamicMode())
         {
             STK_ASSERT(user_task != nullptr);
             STK_ASSERT(IsStarted());
 
-            hw::CriticalSection::ScopedLock cs_;
+            const hw::CriticalSection::ScopedLock cs_;
 
-            KernelTask *task = FindTaskByUserTask(user_task);
+            KernelTask *const task = FindTaskByUserTask(user_task);
             if (task != nullptr)
+            {
                 task->ScheduleRemoval();
+            }
         }
         else
         {
@@ -1015,20 +1096,20 @@ public:
         STK_ASSERT(user_task != nullptr);
 
         bool self = false;
-        KernelTask *task = nullptr;
 
         // avoid race with OnTick
         {
-            hw::CriticalSection::ScopedLock cs_;
+            const hw::CriticalSection::ScopedLock cs_;
 
-            task = FindTaskByUserTask(user_task);
+            KernelTask *const task = FindTaskByUserTask(user_task);
             STK_ASSERT(task != nullptr);
 
             // only suspend if the task is currently awake: if it is already sleeping
             // (e.g. blocked on a mutex or timed Sleep), do not overwrite m_time_sleep,
             // that would corrupt the original sleep state and, for sync-object waits,
             // would interfere with WaitObject::Tick()
-            if ((suspended = !task->IsSleeping()) == true)
+            suspended = !task->IsSleeping();
+            if (suspended == true)
             {
                 task->ScheduleSleep(WAIT_INFINITE);
 
@@ -1039,7 +1120,9 @@ public:
 
         // note: we do not spin long here, kernel will switch this task out from scheduling on the next tick
         if (self)
-            task->BusyWaitWhileSleeping();
+        {
+            m_task_now->BusyWaitWhileSleeping();
+        }
     }
 
     /*! \brief     Resume task.
@@ -1050,54 +1133,60 @@ public:
         STK_ASSERT(user_task != nullptr);
 
         // avoid race with OnTick
-        hw::CriticalSection::ScopedLock cs_;
+        const hw::CriticalSection::ScopedLock cs_;
 
-        KernelTask *task = FindTaskByUserTask(user_task);
+        KernelTask *const task = FindTaskByUserTask(user_task);
         STK_ASSERT(task != nullptr);
 
         if (task->IsSleeping())
+        {
             task->Wake();
+        }
     }
 
-   /*! \brief     Enumerate kernel tasks.
-       \param[in,out] user_tasks: Pointer to the array for IKernelTask pointers.
-       \param[in] max_size: Max size of the provided array.
-       \return    Number of tasks in the array.
-   */
-   size_t EnumerateKernelTasks(IKernelTask **tasks, const size_t max_size) override
+    /*! \brief     Enumerate kernel tasks.
+        \param[in] tasks: Reference to the ArrayView of IKernelTask pointers.
+        \return    Number of tasks in the array.
+    */
+   size_t EnumerateKernelTasks(ArrayView<IKernelTask *> tasks) override
    {
        size_t count = 0U;
+       const size_t limit = Min(tasks.GetSize(), static_cast<size_t>(TASKS_MAX));
 
        // avoid race with OnTick
-       hw::CriticalSection::ScopedLock cs_;
+       const hw::CriticalSection::ScopedLock cs_;
 
-       for (uint32_t i = 0U; i < Min(max_size, static_cast<size_t>(TASKS_MAX)); ++i)
+       for (size_t i = 0U; i < limit; ++i)
        {
-           KernelTask *task = &m_task_storage[i];
+           KernelTask *const task = &m_task_storage[i];
            if (task->IsBusy())
-               tasks[count++] = task;
+           {
+                tasks[count++] = task;
+           }
        }
 
        return count;
    }
-
-    /*! \brief     Enumerate tasks.
-        \param[in,out] user_tasks: Pointer to the array for ITask pointers.
-        \param[in] max_size: Max size of the provided array.
+   
+    /*! \brief     Enumerate user tasks.
+        \param[in] user_tasks: Reference to the ArrayView of ITask pointers.
         \return    Number of tasks in the array.
     */
-    size_t EnumerateTasks(ITask **user_tasks, const size_t max_size) override
+    size_t EnumerateTasks(ArrayView<ITask *> user_tasks) override
     {
         size_t count = 0U;
+        const size_t limit = Min(user_tasks.GetSize(), static_cast<size_t>(TASKS_MAX));
 
         // avoid race with OnTick
-        hw::CriticalSection::ScopedLock cs_;
+        const hw::CriticalSection::ScopedLock cs_;
 
-        for (uint32_t i = 0U; i < Min(max_size, static_cast<size_t>(TASKS_MAX)); ++i)
+        for (size_t i = 0U; i < limit; ++i)
         {
-            KernelTask *task = &m_task_storage[i];
+            KernelTask *const task = &m_task_storage[i];
             if (task->IsBusy())
+            {
                 user_tasks[count++] = task->GetUserTask();
+            }
         }
 
         return count;
@@ -1121,11 +1210,13 @@ public:
         // start tracing
     #if STK_SEGGER_SYSVIEW
         SEGGER_SYSVIEW_Start();
-        for (uint32_t i = 0U; i < TASKS_MAX; ++i)
+        for (size_t i = 0U; i < TASKS_MAX; ++i)
         {
             KernelTask *task = &m_task_storage[i];
             if (task->IsBusy())
+            {
                 SendTaskTraceInfo(task);
+            }
         }
     #endif
 
@@ -1153,7 +1244,7 @@ public:
 
     /*! \brief  Get kernel state.
     */
-    EState GetState() const override { return m_state; }
+    EKernelState GetState() const override { return m_kstate; }
 
 protected:
     /*! \enum  EFsmState
@@ -1208,26 +1299,26 @@ protected:
             SleepTrapStack &sleep = m_sleep_trap[0];
 
             SleepTrapStackMemory wrapper(&sleep.memory);
-            sleep.stack.mode = ACCESS_PRIVILEGED;
+            sleep.stack.access_mode = ACCESS_PRIVILEGED;
         #if STK_NEED_TASK_ID
             sleep.stack.tid  = SYS_TASK_ID_SLEEP;
         #endif
 
-            m_platform.InitStack(STACK_SLEEP_TRAP, &sleep.stack, &wrapper, nullptr);
+            STK_UNUSED(m_platform.InitStack(STACK_SLEEP_TRAP, &sleep.stack, &wrapper, nullptr));
         }
 
         // init stack for an Exit trap
-        if (IsDynamicMode())
+        if __stk_constexpr_cpp17 (IsDynamicMode())
         {
             ExitTrapStack &exit = m_exit_trap[0];
 
             ExitTrapStackMemory wrapper(&exit.memory);
-            exit.stack.mode = ACCESS_PRIVILEGED;
+            exit.stack.access_mode = ACCESS_PRIVILEGED;
         #if STK_NEED_TASK_ID
             exit.stack.tid  = SYS_TASK_ID_EXIT;
         #endif
 
-            m_platform.InitStack(STACK_EXIT_TRAP, &exit.stack, &wrapper, nullptr);
+            STK_UNUSED(m_platform.InitStack(STACK_EXIT_TRAP, &exit.stack, &wrapper, nullptr));
         }
     }
 
@@ -1239,9 +1330,9 @@ protected:
     {
         // look for a free kernel task
         KernelTask *new_task = nullptr;
-        for (uint32_t i = 0U; i < TASKS_MAX; ++i)
+        for (size_t i = 0U; i < TASKS_MAX; ++i)
         {
-            KernelTask *task = &m_task_storage[i];
+            KernelTask *const task = &m_task_storage[i];
             if (task->IsBusy())
             {
                 // avoid task collision
@@ -1257,6 +1348,10 @@ protected:
             #if defined(NDEBUG) && !defined(_STK_ASSERT_REDIRECT)
                 break; // break if assertions are inactive and do not try to validate collision with existing tasks
             #endif
+            }
+            else
+            {
+                // noop, continue to the next slot
             }
         }
 
@@ -1275,7 +1370,7 @@ protected:
     {
     #if STK_SEGGER_SYSVIEW
         // start tracing new task
-        SEGGER_SYSVIEW_OnTaskCreate(task->GetUserStack()->tid);
+        SEGGER_SYSVIEW_OnTaskCreate(task->GetUserStackPtr()->tid);
         if (IsStarted())
             SendTaskTraceInfo(task);
     #endif
@@ -1288,7 +1383,7 @@ protected:
     */
     void AllocateAndAddNewTask(ITask *user_task)
     {
-        KernelTask *task = AllocateNewTask(user_task);
+        KernelTask *const task = AllocateNewTask(user_task);
         STK_ASSERT(task != nullptr);
 
         AddKernelTask(task);
@@ -1303,7 +1398,7 @@ protected:
     */
     void HrtAllocateAndAddNewTask(ITask *user_task, Timeout periodicity_tc, Timeout deadline_tc, Timeout start_delay_tc)
     {
-        KernelTask *task = AllocateNewTask(user_task);
+        KernelTask *const task = AllocateNewTask(user_task);
         STK_ASSERT(task != nullptr);
 
         task->HrtInit(periodicity_tc, deadline_tc, start_delay_tc);
@@ -1315,11 +1410,9 @@ protected:
         \note      Must be called by the task process only!
         \param[in] user_task: User task to add.
     */
-    __stk_attr_noinline void RequestAddTask(ITask *user_task)
+    __stk_attr_noinline void RequestAddTask(ITask *const user_task)
     {
-        STK_ASSERT(IsDynamicMode());
-
-        KernelTask *caller = FindTaskBySP(m_platform.GetCallerSP());
+        KernelTask *const caller = FindTaskBySP(m_platform.GetCallerSP());
         STK_ASSERT(caller != nullptr);
 
         typename KernelTask::AddTaskRequest req = { .user_task = user_task };
@@ -1330,7 +1423,9 @@ protected:
 
         // switch out and wait for completion (due to context switch request could be processed here)
         if (caller->m_srt[0].add_task_req != nullptr)
+        {
             m_service.SwitchToNext();
+        }
 
         STK_ASSERT(caller->m_srt[0].add_task_req == nullptr);
     }
@@ -1341,14 +1436,19 @@ protected:
     */
     __stk_attr_noinline KernelTask *FindTaskByUserTask(const ITask *user_task)
     {
-        for (uint32_t i = 0U; i < TASKS_MAX; ++i)
+        KernelTask *found_task = nullptr;
+      
+        for (size_t i = 0U; i < TASKS_MAX; ++i)
         {
-            KernelTask *task = &m_task_storage[i];
+            KernelTask *const task = &m_task_storage[i];
             if (task->GetUserTask() == user_task)
-                return task;
+            {
+                found_task = task;
+                break;
+            }
         }
 
-        return nullptr;
+        return found_task;
     }
 
     /*! \brief     Find kernel task by the bound Stack instance.
@@ -1357,40 +1457,59 @@ protected:
     */
     KernelTask *FindTaskByStack(const Stack *stack)
     {
-        for (uint32_t i = 0U; i < TASKS_MAX; ++i)
+        KernelTask *found_task = nullptr;
+      
+        for (size_t i = 0U; i < TASKS_MAX; ++i)
         {
-            KernelTask *task = &m_task_storage[i];
-            if (task->GetUserStack() == stack)
-                return task;
+            KernelTask *const task = &m_task_storage[i];
+            if (task->GetUserStackPtr() == stack)
+            {
+                found_task = task;
+                break;
+            }
         }
 
-        return nullptr;
+        return found_task;
     }
 
     /*! \brief     Find kernel task for a Stack Pointer (SP).
         \param[in] SP: Stack pointer.
         \return    Kernel task.
-    */
+    */   
     __stk_attr_noinline KernelTask *FindTaskBySP(Word SP)
     {
         STK_ASSERT(m_task_now != nullptr);
+        
+        KernelTask *found_task = nullptr;
 
         if (m_task_now->IsMemoryOfSP(SP))
-            return m_task_now;
-
-        for (uint32_t i = 0U; i < TASKS_MAX; ++i)
         {
-            KernelTask *task = &m_task_storage[i];
+            found_task = m_task_now;
+        }
+        else
+        {
+            for (size_t i = 0U; i < TASKS_MAX; ++i)
+            {
+                KernelTask *const task = &m_task_storage[i];
 
-            // skip finished tasks (applicable only for KERNEL_DYNAMIC mode)
-            if (IsDynamicMode() && !task->IsBusy())
-                continue;
+                // skip finished tasks (applicable only for KERNEL_DYNAMIC mode)
+                if __stk_constexpr_cpp17 (IsDynamicMode())
+                {
+                    if (!task->IsBusy())
+                    {
+                        continue;
+                    }
+                }
 
-            if (task->IsMemoryOfSP(SP))
-                return task;
+                if (task->IsMemoryOfSP(SP))
+                {
+                    found_task = task;
+                    break;
+                }
+            }
         }
 
-        return nullptr;
+        return found_task;
     }
 
     /*! \brief     Remove kernel task.
@@ -1402,7 +1521,7 @@ protected:
         STK_ASSERT(task != nullptr);
 
     #if STK_SEGGER_SYSVIEW
-        SEGGER_SYSVIEW_OnTaskTerminate(task->GetUserStack()->tid);
+        SEGGER_SYSVIEW_OnTaskTerminate(task->GetUserStackPtr()->tid);
     #endif
 
         // notify task about pending exit
@@ -1427,11 +1546,11 @@ protected:
         STK_ASSERT(m_strategy.GetSize() != 0);
 
         // iterate tasks and generate OnTaskSleep for a strategy for all initially sleeping tasks
-        if (TStrategy::SLEEP_EVENT_API)
+        if __stk_constexpr_cpp17 (TStrategy::SLEEP_EVENT_API)
         {
-            for (uint32_t i = 0U; i < TASKS_MAX; ++i)
+            for (size_t i = 0U; i < TASKS_MAX; ++i)
             {
-                KernelTask *task = &m_task_storage[i];
+                KernelTask *const task = &m_task_storage[i];
 
                 if (task->IsSleeping())
                 {
@@ -1460,10 +1579,12 @@ protected:
             {
                 m_task_now = next;
 
-                active = next->GetUserStack();
+                active = next->GetUserStackPtr();
 
-                if (IsHrtMode())
+                if __stk_constexpr_cpp17 (IsHrtMode())
+                {
                     next->HrtOnSwitchedIn();
+                }
             }
             else
             if (m_fsm_state == FSM_STATE_SLEEPING)
@@ -1474,10 +1595,15 @@ protected:
 
                 active = &m_sleep_trap[0].stack;
             }
+            else
+            {
+                // unexpected state
+                STK_KERNEL_PANIC(KERNEL_PANIC_BAD_STATE);
+            }
         }
 
         // is in running state
-        m_state = STATE_RUNNING;
+        m_kstate = KSTATE_RUNNING;
 
     #if STK_SEGGER_SYSVIEW
         SEGGER_SYSVIEW_OnTaskStartExec(m_task_now->tid);
@@ -1491,12 +1617,12 @@ protected:
     */
     __stk_attr_noinline void OnStop() override
     {
-        if (IsDynamicMode())
+        if __stk_constexpr_cpp17 (IsDynamicMode())
         {
             m_fsm_state = FSM_STATE_NONE;
 
             // is in stopped state, i.e. is ready to Start() again
-            m_state = STATE_READY;
+            m_kstate = KSTATE_READY;
         }
     }
 
@@ -1550,18 +1676,22 @@ protected:
 
     void OnTaskSleep(Word caller_SP, Timeout ticks) override
     {
-        KernelTask *task = FindTaskBySP(caller_SP);
+        KernelTask *const task = FindTaskBySP(caller_SP);
         STK_ASSERT(task != nullptr);
 
         // make change to HRT state and sleep time atomic
         {
-            hw::CriticalSection::ScopedLock cs_;
+            const hw::CriticalSection::ScopedLock cs_;
 
-            if (IsHrtMode())
+            if __stk_constexpr_cpp17 (IsHrtMode())
+            {
                 task->HrtOnWorkCompleted();
+            }
 
             if (ticks > 0)
+            {
                 task->ScheduleSleep(ticks);
+            }
         }
 
         // note: we do not spin long here, kernel will switch this task out from scheduling on the next tick
@@ -1570,24 +1700,26 @@ protected:
 
     bool OnTaskSleepUntil(Word caller_SP, Ticks timestamp) override
     {
-        STK_ASSERT(!IsHrtMode());
-
-        KernelTask *task = FindTaskBySP(caller_SP);
+        KernelTask *const task = FindTaskBySP(caller_SP);
         STK_ASSERT(task != nullptr);
 
         bool result = true;
 
         // make change to HRT state and sleep time atomic
         {
-            hw::CriticalSection::ScopedLock cs_;
+            const hw::CriticalSection::ScopedLock cs_;
 
             // calculate signed delta (handles wrap-around correctly)
             const Ticks delta = timestamp - m_service.m_ticks;
 
             if (delta > 0)
+            {
                 task->ScheduleSleep(static_cast<Timeout>(Min(delta, static_cast<Ticks>(INT32_MAX))));
+            }
             else
+            {
                 result = false; // deadline already hit or passed
+            }
         }
 
         // note: we do not spin long here, kernel will switch this task out from scheduling on the next tick
@@ -1597,21 +1729,23 @@ protected:
 
     void OnTaskSleepCancel(TId task_id)
     {
-        KernelTask *task = FindTaskByUserTask(GetUserTaskFromTid(task_id));
+        KernelTask *const task = FindTaskByUserTask(GetUserTaskFromTid(task_id));
         if (task != nullptr)
         {
-            hw::CriticalSection::ScopedLock cs_;
+            const hw::CriticalSection::ScopedLock cs_;
 
             if (task->IsSleeping())
+            {
                 task->Wake();
+            }
         }
     }
 
     void OnTaskExit(Stack *stack) override
     {
-        if (IsDynamicMode())
+        if __stk_constexpr_cpp17 (IsDynamicMode())
         {
-            KernelTask *task = FindTaskByStack(stack);
+            KernelTask *const task = FindTaskByStack(stack);
             STK_ASSERT(task != nullptr);
 
             // notify kernel to execute removal
@@ -1626,14 +1760,14 @@ protected:
 
     IWaitObject *OnTaskWait(Word caller_SP, ISyncObject *sync_obj, IMutex *mutex, Timeout timeout) override
     {
-        if (IsSyncMode())
+        if __stk_constexpr_cpp17 (IsSyncMode())
         {
             STK_ASSERT(timeout != 0);        // API contract: caller must not be in ISR
             STK_ASSERT(sync_obj != nullptr); // API contract: ISyncObject instance must be provided
             STK_ASSERT(mutex != nullptr);    // API contract: IMutex instance must be provided
             STK_ASSERT((sync_obj->GetHead() == nullptr) || (sync_obj->GetHead() == &m_sync_list[0]));
 
-            KernelTask *task = FindTaskBySP(caller_SP);
+            KernelTask *const task = FindTaskBySP(caller_SP);
             STK_ASSERT(task != nullptr);
 
             // configure waiting
@@ -1641,7 +1775,9 @@ protected:
 
             // register ISyncObject if not yet
             if (sync_obj->GetHead() == nullptr)
+            {
                 m_sync_list->LinkBack(sync_obj);
+            }
 
             // start sleeping infinitely, we rely on a Wake call via WaitObject
             task->ScheduleSleep(WAIT_INFINITE);
@@ -1666,7 +1802,7 @@ protected:
 
     TId OnGetTid(Word caller_SP) override
     {
-        KernelTask *task = FindTaskBySP(caller_SP);
+        KernelTask *const task = FindTaskBySP(caller_SP);
         STK_ASSERT(task != nullptr);
 
         return task->GetTid();
@@ -1674,14 +1810,27 @@ protected:
 
     void OnSuspend(bool suspended) override
     {
+        // toggle kernel state
         if (suspended)
-            m_state = ((m_state == STATE_RUNNING) ? STATE_SUSPENDED : m_state);
+        {
+            if (m_kstate == KSTATE_RUNNING) 
+            {
+                m_kstate = KSTATE_SUSPENDED;
+            }
+        }
         else
-            m_state = ((m_state == STATE_SUSPENDED) ? STATE_RUNNING : m_state);
+        {
+            if (m_kstate == KSTATE_SUSPENDED) 
+            {
+                m_kstate = KSTATE_RUNNING;
+            }
+        }
 
         // force yield for a currently active task
         if (!m_task_now->IsSleeping())
+        {
             m_task_now->ScheduleSleep(YIELD_TICKS);
+        }
     }
 
     void OnInheritWeight(TId tid, Weight weight)
@@ -1691,10 +1840,10 @@ protected:
 
         if (weight != NO_WEIGHT)
         {
-            KernelTask *task = FindTaskByUserTask(GetUserTaskFromTid(tid));
+            KernelTask *const task = FindTaskByUserTask(GetUserTaskFromTid(tid));
             STK_ASSERT(task != nullptr);
 
-            Weight prev_weight = task->GetWeight();
+            const Weight prev_weight = task->GetWeight();
 
             if (prev_weight < weight)
             {
@@ -1709,10 +1858,10 @@ protected:
         STK_ASSERT(tid != TID_NONE);
         STK_ASSERT(TStrategy::WEIGHT_API && TStrategy::PRIORITY_INHERITANCE_API);
 
-        KernelTask *task = FindTaskByUserTask(GetUserTaskFromTid(tid));
+        KernelTask *const task = FindTaskByUserTask(GetUserTaskFromTid(tid));
         STK_ASSERT(task != nullptr);
 
-        Weight prev_weight = task->GetWeight();
+        const Weight prev_weight = task->GetWeight();
 
         // restore to original or boost from wait objects
         task->SetCurrentWeight(sobj != nullptr ? sobj->FindWeightHigherThan(task->GetWeight()) : NO_WEIGHT);
@@ -1725,14 +1874,19 @@ protected:
     Timeout UpdateTasks(const Timeout elapsed_ticks)
     {
         // sync objects are updated before UpdateTaskRequest which may add a new object (newly added object must become 1 tick older)
-        if (IsSyncMode())
+        if __stk_constexpr_cpp17 (IsSyncMode())
+        {
             UpdateSyncObjects(elapsed_ticks);
+        }
 
-        UpdateTaskRequest();
+        if (m_request != REQ_NONE)
+        {
+            UpdateTaskRequest();
+        }
 
         return UpdateTaskState(elapsed_ticks);
     }
-
+        
     /*! \brief     Update task state: process removals, advance sleep timers, and track HRT durations.
         \param[in] elapsed_ticks: Number of ticks elapsed since the previous call.
                    Always 1 in non-tickless mode, may be >1 in tickless mode.
@@ -1744,21 +1898,21 @@ protected:
     */
     Timeout UpdateTaskState(const Timeout elapsed_ticks)
     {
-        Timeout sleep_ticks = (IsTicklessMode() ? STK_TICKLESS_TICKS_MAX : 1);
+        Timeout sleep_ticks = GetInitialSleepTicks<IsTicklessMode()>();
 
-        for (uint32_t i = 0U; i < TASKS_MAX; ++i)
+        for (size_t i = 0U; i < TASKS_MAX; ++i)
         {
-            KernelTask *task = &m_task_storage[i];
+            KernelTask *const task = &m_task_storage[i];
 
             if (task->IsSleeping())
             {
-                if (IsDynamicMode())
+                if __stk_constexpr_cpp17 (IsDynamicMode())
                 {
                     // task is pending removal, wait until it is switched out
                     if (task->IsPendingRemoval())
                     {
                         if ((task != m_task_now) ||
-                            ((m_strategy.GetSize() == 1) && (m_fsm_state == FSM_STATE_SLEEPING)))
+                            ((m_strategy.GetSize() == 1U) && (m_fsm_state == FSM_STATE_SLEEPING)))
                         {
                             RemoveTask(task);
                             continue;
@@ -1768,7 +1922,7 @@ protected:
 
                 // deliver sleep event to strategy
                 // note: only currently scheduled task can be pending to sleep
-                if (TStrategy::SLEEP_EVENT_API)
+                if __stk_constexpr_cpp17 (TStrategy::SLEEP_EVENT_API)
                 {
                     if ((task->m_state & KernelTask::STATE_SLEEP_PENDING) != 0U)
                     {
@@ -1783,41 +1937,52 @@ protected:
                 task->m_time_sleep += elapsed_ticks;
 
                 // deliver sleep event to strategy
-                if (TStrategy::SLEEP_EVENT_API)
+                if __stk_constexpr_cpp17 (TStrategy::SLEEP_EVENT_API)
                 {
                     // notify strategy that task woke up
                     if (!task->IsSleeping())
+                    {
                         m_strategy.OnTaskWake(task);
+                    }
                 }
             }
             else
-            if (IsHrtMode())
             {
-                // in HRT mode we trace how long task spent in active state (doing some work)
-                if (task->IsBusy())
+                if __stk_constexpr_cpp17 (IsHrtMode())
                 {
-                    task->m_hrt[0].duration += elapsed_ticks;
-
-                    // check if deadline is missed (HRT failure)
-                    if (task->HrtIsDeadlineMissed(task->m_hrt[0].duration))
+                    // in HRT mode we trace how long task spent in active state (doing some work)
+                    if (task->IsBusy())
                     {
-                        bool can_recover = false;
+                        task->m_hrt[0].duration += elapsed_ticks;
 
-                        // report deadline overrun to a strategy which supports overrun recovery
-                        if (TStrategy::DEADLINE_MISSED_API)
-                            can_recover = m_strategy.OnTaskDeadlineMissed(task);
-
-                        // report failure if it could not be recovered by a scheduling strategy
-                        if (!can_recover)
-                            task->HrtHardFailDeadline(&m_platform);
+                        // check if deadline is missed (HRT failure)
+                        if (task->HrtIsDeadlineMissed(task->m_hrt[0].duration))
+                        {
+                            // report deadline overrun to a strategy which supports overrun recovery
+                            if __stk_constexpr_cpp17 (TStrategy::DEADLINE_MISSED_API)
+                            {                                
+                                if (!m_strategy.OnTaskDeadlineMissed(task))
+                                {
+                                    // report failure if it could not be recovered by the scheduling strategy
+                                    task->HrtHardFailDeadline(&m_platform);
+                                }
+                            }
+                            else
+                            {
+                                task->HrtHardFailDeadline(&m_platform);
+                            }
+                        }
                     }
                 }
             }
 
             // get the number ticks the driver has to keep CPU in Idle
-            if (IsTicklessMode() && (sleep_ticks > 1) && task->IsBusy())
+            if __stk_constexpr_cpp17 (IsTicklessMode())
             {
-                sleep_ticks = task->GetSleepTicks(sleep_ticks);
+                if ((sleep_ticks > 1) && task->IsBusy())
+                {
+                    sleep_ticks = task->GetSleepTicks(sleep_ticks);
+                }
             }
         }
 
@@ -1828,18 +1993,16 @@ protected:
     */
     void UpdateSyncObjects(const Timeout elapsed_ticks)
     {
-        STK_ASSERT(IsSyncMode());
-
         ISyncObject::ListEntryType *itr = m_sync_list->GetFirst();
 
         while (itr != nullptr)
         {
-            ISyncObject::ListEntryType *next = itr->GetNext();
+            ISyncObject::ListEntryType *const next = itr->GetNext();
 
-            // MISRA 5-2-3 deviation: GetNext/GetFirst returns ISyncObject*, all objects in
-            // m_sync_list are ISyncObject instances - downcast is guaranteed safe
             if (!static_cast<ISyncObject *>(itr)->Tick(elapsed_ticks))
+            {
                 m_sync_list->Unlink(itr);
+            }
 
             itr = next;
         }
@@ -1849,22 +2012,19 @@ protected:
     */
     void UpdateTaskRequest()
     {
-        if (m_request == REQUEST_NONE)
-            return;
-
         // process AddTask requests coming from tasks (KERNEL_DYNAMIC mode only, KERNEL_HRT is
         // excluded as we assume that HRT tasks must be known to the kernel before a Start())
-        if (IsDynamicMode() && !IsHrtMode())
+        if __stk_constexpr_cpp17 (IsDynamicMode() && !IsHrtMode())
         {
             // process serialized AddTask request made from another active task, requesting process
             // is currently waiting due to SwitchToNext()
-            if ((m_request & REQUEST_ADD_TASK) != 0U)
+            if ((m_request & REQ_ADD_TASK) != 0U)
             {
-                m_request &= ~REQUEST_ADD_TASK;
+                m_request &= ~REQ_ADD_TASK;
 
-                for (uint32_t i = 0U; i < TASKS_MAX; ++i)
+                for (size_t i = 0U; i < TASKS_MAX; ++i)
                 {
-                    KernelTask *task = &m_task_storage[i];
+                    KernelTask *const task = &m_task_storage[i];
 
                     if (task->m_srt[0].add_task_req != nullptr)
                     {
@@ -1877,45 +2037,45 @@ protected:
             }
         }
     }
-
+        
     /*! \brief      Fetch next event for the FSM.
         \param[out] next: Next kernel task to which Kernel can switch.
         \return     FSM event.
     */
     EFsmEvent FetchNextEvent(KernelTask *&next)
     {
-        EFsmEvent type = FSM_EVENT_EXIT;
-        KernelTask *itr = nullptr;
+        EFsmEvent type = FSM_EVENT_SLEEP;
 
-        // check if no tasks left in KERNEL_DYNAMIC mode and exit, if KERNEL_DYNAMIC is not
-        // set then 'is_empty' will always be false
-        bool is_empty = IsDynamicMode() && (m_strategy.GetSize() == 0U);
+        // try getting next task for scheduling
+        next = static_cast<KernelTask *>(m_strategy.GetNext());
 
-        if (!is_empty)
+        // sleep-aware strategy returns nullptr if no active tasks available
+        if (next != nullptr)
         {
-            // MISRA 5-2-3 deviation: GetNext/GetFirst returns IKernelTask*, all objects in
-            // the strategy pool are KernelTask instances - downcast is guaranteed safe.
-            itr = static_cast<KernelTask *>(m_strategy.GetNext());
+            // strategy must provide active-only task
+            STK_ASSERT(!next->IsSleeping());
 
-            // sleep-aware strategy returns nullptr if no active tasks available, start sleeping
-            if (itr == nullptr)
+            // if was sleeping, process wake event first
+            type = (m_fsm_state == FSM_STATE_SLEEPING ? FSM_EVENT_WAKE : FSM_EVENT_SWITCH);
+        }
+        // start sleeping
+        else
+        {
+            if __stk_constexpr_cpp17 (IsDynamicMode())
             {
-                type = FSM_EVENT_SLEEP;
-            }
-            else
-            {
-                // strategy must provide active-only task
-                STK_ASSERT(!itr->IsSleeping());
-
-                // if was sleeping, process wake event first
-                type = (m_fsm_state == FSM_STATE_SLEEPING ? FSM_EVENT_WAKE : FSM_EVENT_SWITCH);
+                // if nullptr is returned then either strategy has all tasks sleeping or none left,
+                // if KERNEL_DYNAMIC mode and no tasks left then exit from scheduling
+                if (m_strategy.GetSize() == 0U)
+                {
+                    next = nullptr;
+                    type = FSM_EVENT_EXIT;
+                }
             }
         }
 
-        next = itr;
         return type;
     }
-
+        
     /*! \brief      Get new FSM state.
         \param[out] next: Next kernel task to which Kernel can switch.
         \return     FSM state.
@@ -1936,34 +2096,37 @@ protected:
     */
     bool UpdateFsmState(Stack *&idle, Stack *&active)
     {
-        KernelTask *now = m_task_now, *next = nullptr;
+        KernelTask *const now = m_task_now, *next = nullptr;
         bool switch_context = false;
 
-        EFsmState new_state = GetNewFsmState(next);
+        const EFsmState new_state = GetNewFsmState(next);
 
         switch (new_state)
         {
         case FSM_STATE_SWITCHING:
             switch_context = StateSwitch(now, next, idle, active);
+            m_fsm_state = new_state;
             break;
         case FSM_STATE_SLEEPING:
             switch_context = StateSleep(now, next, idle, active);
+            m_fsm_state = new_state;
             break;
         case FSM_STATE_WAKING:
             switch_context = StateWake(now, next, idle, active);
+            m_fsm_state = new_state;
             break;
         case FSM_STATE_EXITING:
             switch_context = StateExit(now, next, idle, active);
+            m_fsm_state = new_state;
             break;
         case FSM_STATE_NONE:
-            return switch_context; // valid intermittent non-persisting state: no-transition
+            break; // valid intermittent non-persisting state: no-transition
         case FSM_STATE_MAX:
-        default:                   // invalid state value
+        default:   // invalid state value
             STK_KERNEL_PANIC(KERNEL_PANIC_BAD_STATE);
             break;
         }
 
-        m_fsm_state = new_state;
         return switch_context;
     }
 
@@ -1978,39 +2141,43 @@ protected:
     {
         STK_ASSERT(now != nullptr);
         STK_ASSERT(next != nullptr);
+        
+        bool switch_context = false;
 
-        // do not switch context because task did not change
-        if (next == now)
-            return false;
-
-        idle   = now->GetUserStack();
-        active = next->GetUserStack();
-
-        // if stack memory is exceeded these assertions will be hit
-        if (now->IsBusy())
+        // if equal: do not switch context because task did not change
+        if (next != now)
         {
-            // current task could exit, thus we check it with IsBusy to avoid referencing nullptr returned by GetUserTask()
-            STK_ASSERT(now->GetUserTask()->GetStack()[0] == STK_STACK_MEMORY_FILLER);
-        }
-        STK_ASSERT(next->GetUserTask()->GetStack()[0] == STK_STACK_MEMORY_FILLER);
+            idle   = now->GetUserStackPtr();
+            active = next->GetUserStackPtr();
 
-        m_task_now = next;
-
-        if ((IsHrtMode()))
-        {
-            if (now->m_hrt[0].done)
+            // if stack memory is exceeded these assertions will be hit
+            if (now->IsBusy())
             {
-                now->HrtOnSwitchedOut(&m_platform);
-                next->HrtOnSwitchedIn();
+                // current task could exit, thus we check it with IsBusy to avoid referencing nullptr returned by GetUserTask()
+                STK_ASSERT(now->GetUserTask()->GetStack()[0] == STK_STACK_MEMORY_FILLER);
             }
+            STK_ASSERT(next->GetUserTask()->GetStack()[0] == STK_STACK_MEMORY_FILLER);
+
+            m_task_now = next;
+
+            if __stk_constexpr_cpp17 (IsHrtMode())
+            {
+                if (now->m_hrt[0].done)
+                {
+                    now->HrtOnSwitchedOut(&m_platform);
+                    next->HrtOnSwitchedIn();
+                }
+            }
+
+        #if STK_SEGGER_SYSVIEW
+            SEGGER_SYSVIEW_OnTaskStopReady(now->GetUserStackPtr()->tid, TRACE_EVENT_SWITCH);
+            SEGGER_SYSVIEW_OnTaskStartReady(next->GetUserStackPtr()->tid);
+        #endif
+            
+            switch_context = true;
         }
 
-    #if STK_SEGGER_SYSVIEW
-        SEGGER_SYSVIEW_OnTaskStopReady(now->GetUserStack()->tid, TRACE_EVENT_SWITCH);
-        SEGGER_SYSVIEW_OnTaskStartReady(next->GetUserStack()->tid);
-    #endif
-
-        return true; // switch context
+        return switch_context;
     }
 
     /*! \brief      Wakes up after sleeping.
@@ -2027,7 +2194,7 @@ protected:
         STK_ASSERT(next != nullptr);
 
         idle   = &m_sleep_trap[0].stack;
-        active = next->GetUserStack();
+        active = next->GetUserStackPtr();
 
         // if stack memory is exceeded these assertions will be hit
         STK_ASSERT(m_sleep_trap[0].memory[0] == STK_STACK_MEMORY_FILLER);
@@ -2036,11 +2203,13 @@ protected:
         m_task_now = next;
 
     #if STK_SEGGER_SYSVIEW
-        SEGGER_SYSVIEW_OnTaskStartReady(next->GetUserStack()->tid);
+        SEGGER_SYSVIEW_OnTaskStartReady(next->GetUserStackPtr()->tid);
     #endif
 
-        if ((IsHrtMode()))
+        if __stk_constexpr_cpp17 (IsHrtMode())
+        {
             next->HrtOnSwitchedIn();
+        }
 
         return true; // switch context
     }
@@ -2059,19 +2228,21 @@ protected:
         STK_ASSERT(now != nullptr);
         STK_ASSERT(m_sleep_trap[0].stack.SP != 0);
 
-        idle   = now->GetUserStack();
+        idle   = now->GetUserStackPtr();
         active = &m_sleep_trap[0].stack;
 
         m_task_now = static_cast<KernelTask *>(m_strategy.GetFirst());
 
     #if STK_SEGGER_SYSVIEW
-        SEGGER_SYSVIEW_OnTaskStopReady(now->GetUserStack()->tid, TRACE_EVENT_SLEEP);
+        SEGGER_SYSVIEW_OnTaskStopReady(now->GetUserStackPtr()->tid, TRACE_EVENT_SLEEP);
     #endif
 
-        if (IsHrtMode())
+        if __stk_constexpr_cpp17 (IsHrtMode())
         {
             if (!now->IsPendingRemoval())
+            {
                 now->HrtOnSwitchedOut(&m_platform);
+            }
         }
 
         return true; // switch context
@@ -2090,7 +2261,7 @@ protected:
         STK_UNUSED(now);
         STK_UNUSED(next);
 
-        if (IsDynamicMode())
+        if __stk_constexpr_cpp17 (IsDynamicMode())
         {
             // dynamic tasks are not supported if main processes's stack memory is not provided in Start()
             STK_ASSERT(m_exit_trap[0].stack.SP != 0);
@@ -2114,16 +2285,16 @@ protected:
     /*! \brief     Check whether Initialize() has been called and completed successfully.
         \return    \c true if Initialize() was called, \c false otherwise.
     */
-    bool IsInitialized() const { return (m_state != STATE_INACTIVE); }
+    bool IsInitialized() const { return (m_kstate != KSTATE_INACTIVE); }
 
     /*! \brief     Signal the kernel to process a pending AddTask request on the next tick.
-        \note      Sets the REQUEST_ADD_TASK bit in m_request and emits a full memory fence
+        \note      Sets the REQ_ADD_TASK bit in m_request and emits a full memory fence
                    so the ISR-side tick handler observes the flag without delay.
     */
     void ScheduleAddTask()
     {
-        hw::CriticalSection::ScopedLock cs_;
-        m_request |= REQUEST_ADD_TASK;
+        const hw::CriticalSection::ScopedLock cs_;
+        m_request |= REQ_ADD_TASK;
     }
 
 #if STK_SEGGER_SYSVIEW
@@ -2137,7 +2308,7 @@ protected:
 
         SEGGER_SYSVIEW_TASKINFO info =
         {
-            .TaskID    = task->GetUserStack()->tid,
+            .TaskID    = task->GetUserStackPtr()->tid,
             .sName     = task->GetUserTask()->GetTraceName(),
             .Prio      = 0,
             .StackBase = hw::PtrToWord(task->GetUserTask()->GetStack()),
@@ -2148,14 +2319,14 @@ protected:
 #endif
 
     // Kernel modes:
-    static __stk_forceinline bool IsStaticMode() { return ((TMode & KERNEL_STATIC) != 0U); }
-    static __stk_forceinline bool IsDynamicMode() { return ((TMode & KERNEL_DYNAMIC) != 0U); }
-    static __stk_forceinline bool IsHrtMode() { return ((TMode & KERNEL_HRT) != 0U); }
-    static __stk_forceinline bool IsSyncMode() { return ((TMode & KERNEL_SYNC) != 0U); }
-    static __stk_forceinline bool IsTicklessMode() { return ((TMode & KERNEL_TICKLESS) != 0U); }
+    static constexpr bool IsStaticMode()   { return ((TMode & KERNEL_STATIC) != 0U); }
+    static constexpr bool IsDynamicMode()  { return ((TMode & KERNEL_DYNAMIC) != 0U); }
+    static constexpr bool IsHrtMode()      { return ((TMode & KERNEL_HRT) != 0U); }
+    static constexpr bool IsSyncMode()     { return ((TMode & KERNEL_SYNC) != 0U); }
+    static constexpr bool IsTicklessMode() { return ((TMode & KERNEL_TICKLESS) != 0U); }
 
     // If hit here: Kernel<N> expects at least 1 task, e.g. N > 0
-    STK_STATIC_ASSERT_N(TASKS_MAX, TASKS_MAX > 0U);
+    STK_STATIC_ASSERT_N(TASKS_MAX, TASKS_MAX != 0U);
 
     // If hit here: Kernel mode must be assigned.
     STK_STATIC_ASSERT_N(KERNEL_MODE_MUST_BE_SET, (TMode != 0U));
@@ -2229,7 +2400,7 @@ protected:
     ExitTrapStack    m_exit_trap[STK_ALLOCATE_COUNT<TMode, KERNEL_DYNAMIC, 1U, 0U>::Value]; //!< Exit trap: zero-size in KERNEL_STATIC mode; one entry in KERNEL_DYNAMIC mode.
     EFsmState        m_fsm_state;       //!< Current FSM state. Drives context-switch decision on every tick.
     volatile uint8_t m_request;         //!< Bitmask of pending ERequest flags from running tasks. Written by tasks, read/cleared by UpdateTaskRequest() in tick context.
-    volatile EState  m_state;           //!< Current kernel state.
+    volatile EKernelState m_kstate;     //!< Current kernel state.
     SyncObjectList   m_sync_list[STK_ALLOCATE_COUNT<TMode, KERNEL_SYNC, 1U, 0U>::Value]; //!< List of active sync objects. Zero-size (no memory) if KERNEL_SYNC is not set.
 
     const EFsmState  m_fsm[FSM_STATE_MAX][FSM_EVENT_MAX] = {

--- a/stk/include/stk_arch.h
+++ b/stk/include/stk_arch.h
@@ -44,10 +44,22 @@
 #define _STK_ARCH_DEFINED
 #endif
 
+#ifndef STK_PANIC_HANDLER
+    /*! \brief Default panic handler: disable interrupts, record the id,
+               and spin in a tight loop — a defined, detectable safe state.
+        \note  On a system with a watchdog enabled this will trigger a watchdog
+               reset after the watchdog period, which is the desired behaviour.
+        \note  Replace with a platform-specific handler (e.g. one that writes a
+               fault log to non-volatile memory and calls NVIC_SystemReset()) by
+               defining STK_PANIC_HANDLER in stk_config.h.
+    */
+    extern void STK_PANIC_HANDLER_DEFAULT(stk::EKernelPanicId id);
+    #define STK_PANIC_HANDLER(id) STK_PANIC_HANDLER_DEFAULT(id)
+#endif
+
 namespace stk {
 
-/*! \def   STK_KERNEL_PANIC
-    \brief Called when the kernel detects an unrecoverable internal fault.
+/*! \brief Called when the kernel detects an unrecoverable internal fault.
     \note  Unlike STK_ASSERT (which checks preconditions) this macro is reached only
            when a runtime invariant has been irreversibly violated — the kernel
            cannot continue operating correctly from this point.
@@ -60,11 +72,11 @@ namespace stk {
            and must never return. A minimal safe default is provided below.
     \param[in] id: EKernelPanicId value identifying the fault.
 */
-#define STK_KERNEL_PANIC(id)                         \
-    do {                                             \
-        __stk_debug_break();   /* debug aid */       \
-        STK_PANIC_HANDLER(id); /* must not return */ \
-    } while (0)
+static __stk_forceinline void STK_KERNEL_PANIC(stk::EKernelPanicId id)
+{
+    __stk_debug_break();   // debug aid
+    STK_PANIC_HANDLER(id); // must not return
+}
 
 /*! \namespace stk::hw
     \brief     Hardware Abstraction Layer (HAL) for architecture-specific operations.
@@ -91,7 +103,7 @@ namespace hw {
     \see       WordToPtr
 */
 template <typename T>
-static constexpr Word PtrToWord(T *ptr) noexcept
+static constexpr Word PtrToWord(T *const ptr) noexcept
 {
     STK_STATIC_ASSERT(sizeof(Word) == sizeof(T *));
     return reinterpret_cast<Word>(ptr);
@@ -466,10 +478,11 @@ struct HiResClock
     */
     static inline Ticks GetTimeUs()
     {
-        uint32_t freq = GetFrequency();
-        STK_ASSERT(freq != 0);
+        const uint32_t freq = GetFrequency();
+        STK_ASSERT(freq != 0U);
 
-        return ((freq != 0) ? static_cast<Ticks>((GetCycles() * 1000000ULL) / freq) : 0 );
+        return ((freq != 0U) ? 
+            static_cast<Ticks>((GetCycles() * 1000000ULL) / freq) : static_cast<Ticks>(0));
     }
 };
 
@@ -488,18 +501,5 @@ static constexpr TId GetTidFromUserTask(const ITask *task) noexcept { return hw:
 static constexpr ITask *GetUserTaskFromTid(TId task_id) noexcept { return hw::WordToPtr<ITask>(task_id); }
 
 } // namespace stk
-
-#ifndef STK_PANIC_HANDLER
-    /*! \brief Default panic handler: disable interrupts, record the id,
-               and spin in a tight loop — a defined, detectable safe state.
-        \note  On a system with a watchdog enabled this will trigger a watchdog
-               reset after the watchdog period, which is the desired behaviour.
-        \note  Replace with a platform-specific handler (e.g. one that writes a
-               fault log to non-volatile memory and calls NVIC_SystemReset()) by
-               defining STK_PANIC_HANDLER in stk_config.h.
-    */
-    extern void STK_PANIC_HANDLER_DEFAULT(stk::EKernelPanicId id);
-    #define STK_PANIC_HANDLER(id) STK_PANIC_HANDLER_DEFAULT(id)
-#endif
 
 #endif /* STK_ARCH_H_ */

--- a/stk/include/stk_common.h
+++ b/stk/include/stk_common.h
@@ -51,16 +51,17 @@ enum EKernelMode : uint8_t
 */
 enum EKernelPanicId : uint32_t
 {
-    KERNEL_PANIC_NONE                = 0, //!< Panic is absent (no fault).
-    KERNEL_PANIC_SPINLOCK_DEADLOCK   = 1, //!< Spin-lock timeout expired: lock owner never released.
-    KERNEL_PANIC_STACK_CORRUPT       = 2, //!< Stack integrity check failed.
-    KERNEL_PANIC_ASSERT              = 3, //!< Internal assertion failed (maps from STK_ASSERT).
-    KERNEL_PANIC_HRT_HARD_FAULT      = 4, //!< Kernel running in KERNEL_HRT mode reported deadline failure of the task.
-    KERNEL_PANIC_CPU_EXCEPTION       = 5, //!< CPU reported an exception and halted execution.
-    KERNEL_PANIC_CS_NESTING_OVERFLOW = 6, //!< Critical section nesting limit exceeded: violation of STK_CRITICAL_SECTION_NESTINGS_MAX.
-    KERNEL_PANIC_UNKNOWN_SVC         = 7, //!< Unknown service command received by SVC handler.
-    KERNEL_PANIC_BAD_STATE           = 8, //!< Kernel entered unexpected (bad) state.
-    KERNEL_PANIC_BAD_MODE            = 9  //!< Kernel is in bad/unsupported mode for the current operation.
+    KERNEL_PANIC_NONE                = 0U,  //!< Panic is absent (no fault).
+    KERNEL_PANIC_SPINLOCK_DEADLOCK   = 1U,  //!< Spin-lock timeout expired: lock owner never released.
+    KERNEL_PANIC_STACK_CORRUPT       = 2U,  //!< Stack integrity check failed.
+    KERNEL_PANIC_ASSERT              = 3U,  //!< Internal assertion failed (maps from STK_ASSERT).
+    KERNEL_PANIC_HRT_HARD_FAULT      = 4U,  //!< Kernel running in KERNEL_HRT mode reported deadline failure of the task.
+    KERNEL_PANIC_CPU_EXCEPTION       = 5U,  //!< CPU reported an exception and halted execution.
+    KERNEL_PANIC_CS_NESTING_OVERFLOW = 6U,  //!< Critical section nesting limit exceeded: violation of STK_CRITICAL_SECTION_NESTINGS_MAX.
+    KERNEL_PANIC_UNKNOWN_SVC         = 7U,  //!< Unknown service command received by SVC handler.
+    KERNEL_PANIC_BAD_STATE           = 8U,  //!< Kernel entered unexpected (bad) state.
+    KERNEL_PANIC_BAD_MODE            = 9U,  //!< Kernel is in bad/unsupported mode for the current operation.
+    KERNEL_PANIC_BAD_STACK_TYPE      = 10U  //!< Stack type is unknown.
 };
 
 /*! \enum  EStackType
@@ -208,8 +209,49 @@ static constexpr Weight DEFAULT_WEIGHT = static_cast<Weight>(1);
     \note      ISR-safe (bitmask arithmetic only, no kernel calls).
     \see       TID_ISR_N
 */
-static inline bool IsIsrTid(TId tid) { return ((tid & TID_ISR_N) == TID_ISR_N); }
+static inline bool IsIsrTid(TId id) { return ((id & TID_ISR_N) == TID_ISR_N); }
 
+/*! \class ArrayView
+    \brief Lightweight, non-owning view over a contiguous sequence of elements.
+    \note  This descriptor provides a safe encapsulation over raw pointers without 
+           copying the underlying data.
+
+    Usage example:
+    \code
+    stk::ITask *tasks[TASKS_MAX];
+    ArrayView<stk::ITask *> view(tasks, TASKS_MAX);
+    \endcode
+*/
+template <typename T> class ArrayView
+{
+public:
+/*! \brief   Construct an ArrayView from a raw pointer and size.
+        \param[in] ptr: Pointer to the first element of the contiguous memory block.
+        \param[in] size: Number of elements available in the memory block.
+    */
+    ArrayView(T *ptr, size_t size) : m_ptr(ptr), m_size(size)
+    {}
+
+    /*! \brief   Subscript operator for element access.
+        \param   index Element index to access.
+        \return  Reference to the element at the specified index.
+        \warning Triggers STK_ASSERT if index is out of bounds in a Debug build.
+    */
+    T &operator[](size_t index) const
+    {
+        STK_ASSERT(index < m_size);
+        return m_ptr[index];
+    }
+    
+    /*! \brief   Get number of elements in the view.
+        \return  The size of the array view.
+    */
+    size_t GetSize() const { return m_size; }
+
+private:
+    T     *m_ptr;  //!< Pointer to the underlying memory block.
+    size_t m_size; //!< Total number of elements in the view.
+};
 
 /*! \class StackMemoryDef
     \brief Stack memory type definition.
@@ -236,14 +278,14 @@ template <size_t _StackSize> struct StackMemoryDef
 */
 struct Stack
 {
-    Word        SP;   //!< Stack Pointer (SP) register (note: must be the first entry in this struct).
-    EAccessMode mode; //!< Hardware access mode of the owning task (see \a EAccessMode).
+    Word        SP;          //!< Stack Pointer (SP) register (note: must be the first entry in this struct).
+    EAccessMode access_mode; //!< Hardware access mode of the owning task (see \a EAccessMode).
 #if STK_STACK_NEEDS_TASK_ID
-    TId         tid;  //!< Task id (see \a STK_SEGGER_SYSVIEW).
+    TId         tid;         //!< Task id (see \a STK_SEGGER_SYSVIEW).
 #endif
 #ifdef _STK_ARCH_ARM_CORTEX_M
 #if STK_TLS && !STK_TLS_PREFER_REGISTER
-    Word        tls;  //!< Thread-local storage if not using ARM Cortex-M R9 register for a fast inline access to TLS.
+    Word        tls;        //!< Thread-local storage if not using ARM Cortex-M R9 register for a fast inline access to TLS.
 #endif
 #endif
 };
@@ -275,12 +317,11 @@ public:
     */
     virtual size_t GetStackSpace() const
     {
-        const Word *stack = GetStack();
-        const size_t stack_size = GetStackSize();
-
+        ArrayView<const Word> stack(GetStack(), GetStackSize());
+      
         // count leading Words equal to STK_STACK_MEMORY_FILLER (watermark)
         size_t space = 0U;
-        for ( ; (space < stack_size) && (stack[space] == STK_STACK_MEMORY_FILLER); ++space)
+        for ( ; (space < stack.GetSize()) && (stack[space] == STK_STACK_MEMORY_FILLER); ++space)
         {}
 
         return space;
@@ -327,6 +368,11 @@ public:
         \return    Returns \a true if update caused a timeout of the object, \a false otherwise.
     */
     virtual bool Tick(Timeout elapsed_ticks) = 0;
+    
+protected:
+    /*! \brief Destructor.
+    */
+    ~IWaitObject() = default;
 };
 
 /*! \class ITraceable
@@ -367,6 +413,10 @@ public:
     }
 
 protected:
+    /*! \brief Destructor.
+    */
+    ~ITraceable() = default;
+  
 #if STK_SYNC_DEBUG_NAMES
     const char *m_trace_name; //!< name (debug/tracing only)
 #endif
@@ -380,11 +430,6 @@ class ISyncObject : public util::DListEntry<ISyncObject, false>
     friend class IKernel;
 
 public:
-    /*! \brief Destructor.
-        \note  MISRA deviation: [STK-DEV-005] Rule 10-3-2.
-    */
-    ~ISyncObject() = default;
-
     /*! \typedef   ListHeadType
         \brief     List head type for ISyncObject elements.
     */
@@ -442,6 +487,11 @@ protected:
     */
     explicit ISyncObject() : m_wait_list()
     {}
+    
+    /*! \brief Destructor.
+        \note  MISRA deviation: [STK-DEV-005] Rule 10-3-2.
+    */
+    ~ISyncObject() = default;
 
     /*! \brief     Wake the first task in the wait list (FIFO order).
         \note      The woken task is notified with timeout=false, indicating a successful signal
@@ -452,7 +502,9 @@ protected:
     void WakeOne()
     {
         if (!m_wait_list.IsEmpty())
+        {
             static_cast<IWaitObject *>(m_wait_list.GetFirst())->Wake(false);
+        }
     }
 
     /*! \brief     Wake all tasks currently in the wait list.
@@ -464,7 +516,9 @@ protected:
     void WakeAll()
     {
         while (!m_wait_list.IsEmpty())
+        {
             static_cast<IWaitObject *>(m_wait_list.GetFirst())->Wake(false);
+        }
     }
 
     IWaitObject::ListHeadType m_wait_list; //!< tasks blocked on this object
@@ -501,6 +555,11 @@ public:
     /*! \brief Unlock the mutex.
     */
     virtual void Unlock() = 0;
+    
+protected:
+    /*! \brief Destructor.
+    */
+    ~IMutex() = default;
 };
 
 /*! \class ITask
@@ -614,10 +673,11 @@ public:
     /*! \brief     Get user task.
     */
     virtual ITask *GetUserTask() = 0;
-
-    /*! \brief     Get pointer to the user task's stack.
+    
+    /*! \brief      Get user task's Stack info.
+        \param[out] stack: Stack info.
     */
-    virtual Stack *GetUserStack() = 0;
+    virtual Stack GetUserStack() const = 0;
 
     /*! \brief     Get static base weight assigned to the task.
         \return    Static weight value of the task.
@@ -670,6 +730,11 @@ public:
                    will trigger an assertion in the concrete implementation.
     */
     virtual void Wake() = 0;
+    
+protected:
+    /*! \brief Destructor.
+    */
+    ~IKernelTask() = default;
 };
 
 /*! \class IPlatform
@@ -918,6 +983,11 @@ public:
         \note      ISR-safe.
     */
     virtual void Resume(Timeout elapsed_ticks) = 0;
+    
+protected:
+    /*! \brief Destructor.
+    */
+    ~IPlatform() = default;
 };
 
 /*! \class ITaskSwitchStrategy
@@ -1031,6 +1101,11 @@ public:
         STK_UNUSED(task);
         STK_UNUSED(old_weight);
     }
+    
+protected:
+    /*! \brief Destructor.
+    */
+    ~ITaskSwitchStrategy() = default;
 };
 
 /*! \class IKernel
@@ -1044,12 +1119,12 @@ public:
     /*! \enum    EState
         \brief   Kernel state.
     */
-    enum EState : uint8_t
+    enum EKernelState : uint8_t
     {
-        STATE_INACTIVE = 0, //!< Not ready, IKernel::Initialize() must be called.
-        STATE_READY,        //!< Ready to start, IKernel::Start() must be called.
-        STATE_RUNNING,      //!< Initialized and running, IKernel::Start() was called successfully.
-        STATE_SUSPENDED     //!< Scheduling is suspended with IKernelService::Suspend().
+        KSTATE_INACTIVE = 0, //!< Not ready, IKernel::Initialize() must be called.
+        KSTATE_READY,        //!< Ready to start, IKernel::Start() must be called.
+        KSTATE_RUNNING,      //!< Initialized and running, IKernel::Start() was called successfully.
+        KSTATE_SUSPENDED     //!< Scheduling is suspended with IKernelService::Suspend().
     };
 
     /*! \brief     Initialize kernel.
@@ -1114,20 +1189,18 @@ public:
     virtual void ResumeTask(ITask *user_task) = 0;
 
     /*! \brief     Enumerate kernel tasks.
-        \param[in,out] tasks: Pointer to the array for IKernelTask pointers.
-        \param[in] max_size: Max size of the provided array.
+        \param[in] tasks: Reference to the ArrayView of IKernelTask pointers.
         \return    Number of tasks in the array.
         \warning   ISR-safe.
     */
-    virtual size_t EnumerateKernelTasks(IKernelTask **tasks, size_t max_size) = 0;
+    virtual size_t EnumerateKernelTasks(ArrayView<IKernelTask *> tasks) = 0;
 
     /*! \brief     Enumerate user tasks.
-        \param[in,out] user_tasks: Pointer to the array for ITask pointers.
-        \param[in] max_size: Max size of the provided array.
+        \param[in] user_tasks: Reference to the ArrayView of ITask pointers.
         \return    Number of tasks in the array.
         \warning   ISR-safe.
     */
-    virtual size_t EnumerateTasks(ITask **user_tasks, size_t max_size) = 0;
+    virtual size_t EnumerateTasks(ArrayView<ITask *> user_tasks) = 0;
 
     /*! \brief     Enumerate tasks, invoking a callback for each active task.
         \tparam    TMaxCount: Maximum number of tasks to enumerate.
@@ -1152,15 +1225,17 @@ public:
     template <size_t TMaxCount, typename TCallback>
     size_t EnumerateTasksT(TCallback &&callback)
     {
-        STK_STATIC_ASSERT(TMaxCount > 0);
+        STK_STATIC_ASSERT(TMaxCount > 0U);
 
-        ITask *tasks[TMaxCount] = {};
-        size_t i = 0, count = EnumerateTasks(tasks, TMaxCount);
+        ITask *tasks[TMaxCount] = {};        
+        size_t count = EnumerateTasks(ArrayView<ITask *>(tasks, TMaxCount));
+        size_t i = 0U;
+        bool fetch_next = true;
 
-        while (i < count)
+        while ((i < count) && fetch_next)
         {
-            if (!callback(tasks[i++]))
-                break;
+            fetch_next = callback(tasks[i]);
+            ++i;
         }
 
         return i;
@@ -1176,7 +1251,7 @@ public:
         \return    Kernel state.
         \see       EState
     */
-    virtual EState GetState() const = 0;
+    virtual EKernelState GetState() const = 0;
 
     /*! \brief     Get platform driver instance.
         \return    Pointer to the IPlatform concrete class instance.
@@ -1187,6 +1262,11 @@ public:
         \return    Pointer to the ITaskSwitchStrategy concrete class instance.
     */
     virtual ITaskSwitchStrategy *GetSwitchStrategy() = 0;
+    
+protected:
+    /*! \brief Destructor.
+    */
+    ~IKernel() = default;
 };
 
 /*! \class IKernelService
@@ -1327,6 +1407,11 @@ public:
         \note      ISR-safe.
     */
     virtual void RestoreWeight(TId tid, ISyncObject *sobj = nullptr) = 0;
+    
+protected:
+    /*! \brief Destructor.
+    */
+    ~IKernelService() = default;
 };
 
 } // namespace stk

--- a/stk/include/stk_defs.h
+++ b/stk/include/stk_defs.h
@@ -39,7 +39,15 @@
     \see   KERNEL_TICKLESS, STK_TICKLESS_USE_ARM_DWT, STK_TICKLESS_TICKS_MAX
 */
 #ifndef STK_TICKLESS_IDLE
-    #define STK_TICKLESS_IDLE 0
+    #define STK_TICKLESS_IDLE (0)
+#endif
+      
+/*! \def   STK_STRICT_COMPLIANCY
+    \brief Allow the use of workarounds to make binary smaller and faster.
+    \note  Applied workarounds will break safety-critical rules (MISRA, etc).
+*/
+#ifndef STK_STRICT_COMPLIANCY
+    #define STK_STRICT_COMPLIANCY (0)
 #endif
 
 /*! \def   STK_TICKLESS_USE_ARM_DWT
@@ -51,7 +59,7 @@
            timer rearm and does not require rearm-error compensation.
 */
 #ifndef STK_TICKLESS_USE_ARM_DWT
-    #define STK_TICKLESS_USE_ARM_DWT 1
+    #define STK_TICKLESS_USE_ARM_DWT (1)
 #endif
 
 /*! \def   STK_TICKLESS_TICKS_MAX
@@ -65,7 +73,7 @@
     \see   STK_TICKLESS_IDLE, KERNEL_TICKLESS
 */
 #ifndef STK_TICKLESS_TICKS_MAX
-    #define STK_TICKLESS_TICKS_MAX 1000
+    #define STK_TICKLESS_TICKS_MAX (1000)
 #endif
 #if STK_TICKLESS_TICKS_MAX > 100000
     #error "STK_TICKLESS_TICKS_MAX is too large: cpu_ticks_requested may overflow uint32_t."
@@ -87,7 +95,7 @@
     \see   STK_TLS_PREFER_REGISTER, stk::hw::GetTlsPtr, stk::hw::SetTlsPtr
 */
 #ifndef STK_TLS
-    #define STK_TLS 0
+    #define STK_TLS (0)
 #endif
 
 /*! \def   STK_TLS_PREFER_REGISTER
@@ -115,7 +123,7 @@
     \see   STK_TLS, stk::hw::GetTlsPtr, stk::hw::SetTlsPtr
 */
 #ifndef STK_TLS_PREFER_REGISTER
-    #define STK_TLS_PREFER_REGISTER 0
+    #define STK_TLS_PREFER_REGISTER (0)
 #endif
 
 /*! \def   STK_NEED_TASK_ID
@@ -127,7 +135,7 @@
     \see   STK_SEGGER_SYSVIEW, stk::Stack
 */
 #if STK_SEGGER_SYSVIEW
-    #define STK_STACK_NEEDS_TASK_ID 1
+    #define STK_STACK_NEEDS_TASK_ID (1)
 #endif
 
 /*! \def   STK_SYNC_DEBUG_NAMES
@@ -138,9 +146,18 @@
     \note  Default: 0 (disabled) unless STK_SEGGER_SYSVIEW is active.
 */
 #if !defined(STK_SYNC_DEBUG_NAMES) && STK_SEGGER_SYSVIEW
-    #define STK_SYNC_DEBUG_NAMES 1
+    #define STK_SYNC_DEBUG_NAMES (1)
 #elif !defined(STK_SYNC_DEBUG_NAMES)
-    #define STK_SYNC_DEBUG_NAMES 0
+    #define STK_SYNC_DEBUG_NAMES (0)
+#endif
+
+/*! \def   STK_VIRT_DTOR
+    \brief Makes destructors virtual and compliant to strict rules if STK_STRICT_COMPLIANCY=0.
+*/
+#if !STK_STRICT_COMPLIANCY
+    #define STK_VIRT_DTOR
+#else
+    #define STK_VIRT_DTOR virtual
 #endif
 
 /*! \def   __stk_forceinline
@@ -357,6 +374,16 @@
     #define __stk_debug_break()
 #endif
 
+/*! \def   __stk_constexpr_cpp17
+    \brief constexpr definition for C++17 and above.
+    \note  Can be used as 'if __stk_constexpr_cpp17 (x) {}' with C++11 without a warning.
+*/
+#if (__cplusplus >= 201703L) || (defined(_MSVC_LANG) && (_MSVC_LANG >= 201703L))
+    #define __stk_constexpr_cpp17 constexpr
+#else
+    #define __stk_constexpr_cpp17
+#endif
+
 /*! \def   STK_ASSERT
     \brief Runtime assertion. Halts execution if the expression \a e evaluates to false.
     \note  Behaviour depends on build configuration:
@@ -428,7 +455,7 @@
            Can be overridden by defining STK_STACK_MEMORY_FILLER before including this header or in stk_config.h.
 */
 #ifndef STK_STACK_MEMORY_FILLER
-    #define STK_STACK_MEMORY_FILLER ((stk::Word)((sizeof(stk::Word) <= 4U) ? 0xdeadbeefu : 0xdeadbeefdeadbeefull))
+    #define STK_STACK_MEMORY_FILLER (static_cast<stk::Word>((sizeof(stk::Word) <= 4U) ? 0xDEADBEEFU : 0xDEADBEEFDEADBEEFULL))
 #endif
 
 /*! \def   STK_STACK_MEMORY_ALIGN
@@ -436,11 +463,11 @@
 */
 #ifndef STK_STACK_MEMORY_ALIGN
     #if defined(__riscv)
-        #define STK_STACK_MEMORY_ALIGN 16U
+        #define STK_STACK_MEMORY_ALIGN (16U)
     #elif defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_X64)
-        #define STK_STACK_MEMORY_ALIGN 8U
+        #define STK_STACK_MEMORY_ALIGN (8U)
     #else // ARM, others
-        #define STK_STACK_MEMORY_ALIGN 4U
+        #define STK_STACK_MEMORY_ALIGN (4U)
     #endif
 #endif
 
@@ -455,7 +482,7 @@
            Can be overridden in stk_config.h based on Worst-Case Stack Usage (WCSU) analysis.
 */
 #ifndef STK_CRITICAL_SECTION_NESTINGS_MAX
-    #define STK_CRITICAL_SECTION_NESTINGS_MAX 16U
+    #define STK_CRITICAL_SECTION_NESTINGS_MAX (16U)
 #endif
 
 /*! \def   STK_ARCH_CPU_COUNT
@@ -465,7 +492,7 @@
            targets. Can be defined in the architecture header or stk_config.h.
 */
 #ifndef STK_ARCH_CPU_COUNT
-    #define STK_ARCH_CPU_COUNT 1U
+    #define STK_ARCH_CPU_COUNT (1U)
 #endif
 
 /*! \def   STK_STACK_SIZE_MIN
@@ -488,7 +515,7 @@
         #if defined(__riscv_32e) && (__riscv_32e == 1)
             // RISC-V RV32E (Embedded): Small 16-register file
             #if !defined(__riscv_flen) || (__riscv_flen == 0)
-                #define STK_STACK_SIZE_MIN 32U
+                #define STK_STACK_SIZE_MIN (32U)
             #else
                 // FPU present: Requires additional space for 32 FP registers
                 #define STK_STACK_SIZE_MIN (32U + (__riscv_flen * 2))
@@ -497,7 +524,7 @@
             // Standard RISC-V (RV32I/RV64I): Large 32-register file
             // Higher minimum to prevent memory corruption on platforms like RP2350
             #if !defined(__riscv_flen) || (__riscv_flen == 0)
-                #define STK_STACK_SIZE_MIN 256U
+                #define STK_STACK_SIZE_MIN (256U)
             #else
                 // Standard RISC-V with FPU: Maximum frame allocation
                 #define STK_STACK_SIZE_MIN (512U + (__riscv_flen * 2))
@@ -505,7 +532,7 @@
         #endif
     #else
         // ARM Cortex-M and other architectures
-        #define STK_STACK_SIZE_MIN 32U
+        #define STK_STACK_SIZE_MIN (32U)
     #endif
 #endif
 
@@ -580,13 +607,13 @@ struct STK_ALLOCATE_COUNT
 /*! \def       STK_UNUSED
     \brief     Explicitly marks a variable as unused to suppress compiler warnings.
 */
-#define STK_UNUSED(X) static_cast<void>(X)
+#define STK_UNUSED(X) static_cast<void>((X))
 
 /*! \brief     A wrapper for a built-in memcpy, redefine to your own if required.
     \note      Can be overridden by defining _STK_CUSTOM_MEMCPY in system configuration.
 */
 #ifndef _STK_CUSTOM_MEMCPY
-#include <string.h>
+#include <cstring>
 static __stk_forceinline void STK_MEMCPY(void *const dest, const void *const src, const size_t size)
 {
     /* MISRA-compliant explicitly-typed call to underlying implementation */

--- a/stk/include/stk_helper.h
+++ b/stk/include/stk_helper.h
@@ -172,6 +172,11 @@ private:
     MemoryType *m_stack; //!< Pointer to the externally-owned stack memory array.
 };
 
+// Helper function for Kernel::UpdateTaskState.
+template <bool TicklessMode> inline Timeout GetInitialSleepTicks();
+template <> inline Timeout GetInitialSleepTicks<true>()  { return STK_TICKLESS_TICKS_MAX; }
+template <> inline Timeout GetInitialSleepTicks<false>() { return 1; }
+
 //! Implementation of ISyncObject::Tick, see \a ISyncObject. Placed here as it depends on hw namespace.
 inline bool ISyncObject::Tick(Timeout elapsed_ticks)
 {
@@ -192,10 +197,12 @@ inline bool ISyncObject::Tick(Timeout elapsed_ticks)
 
     while (itr != nullptr)
     {
-        IWaitObject *next = static_cast<IWaitObject *>(itr->GetNext());
+        IWaitObject *const next = static_cast<IWaitObject *>(itr->GetNext());
 
         if (!itr->Tick(elapsed_ticks))
+        {
             itr->Wake(true);
+        }
 
         itr = next;
     }
@@ -207,13 +214,17 @@ inline bool ISyncObject::Tick(Timeout elapsed_ticks)
 inline Weight ISyncObject::FindWeightHigherThan(Weight comp) const
 {
     Weight max_weight = NO_WEIGHT;
+    const IWaitObject *itr = static_cast<const IWaitObject *>(m_wait_list.GetFirst());     
 
-    for (const IWaitObject *itr = static_cast<const IWaitObject *>(m_wait_list.GetFirst()); (itr != nullptr);
-            itr = static_cast<const IWaitObject *>(itr->GetNext()))
+    while (itr != nullptr)
     {
-        Weight w = GetUserTaskFromTid(itr->GetTid())->GetWeight();
+        const Weight w = GetUserTaskFromTid(itr->GetTid())->GetWeight();
         if (w > max_weight)
+        {
             max_weight = w;
+        }
+            
+        itr = static_cast<const IWaitObject *>(itr->GetNext());
     }
 
     return ((max_weight > comp) ? max_weight : NO_WEIGHT);
@@ -235,14 +246,14 @@ __stk_forceinline TId GetTid()
 }
 
 /*! \brief     Convert ticks to milliseconds.
-    \param[in] ticks: Tick count to convert.
+    \param[in] tick_count: Tick count to convert.
     \param[in] resolution: Microseconds per tick, as returned by IKernelService::GetTickResolution().
     \return    Equivalent time in milliseconds.
     \note      ISR-safe (performs only arithmetic, no kernel calls).
 */
-__stk_forceinline Time GetMsFromTicks(Ticks ticks, uint32_t resolution)
+__stk_forceinline Time GetMsFromTicks(Ticks tick_count, uint32_t resolution)
 {
-    return static_cast<Time>((ticks * static_cast<Ticks>(resolution)) / 1000LL);
+    return static_cast<Time>((tick_count * static_cast<Time>(resolution)) / 1000LL);
 }
 
 /*! \brief     Convert milliseconds to ticks.
@@ -270,7 +281,7 @@ __stk_forceinline Ticks GetTicks()
     \note      ISR-safe.
     \return    Microseconds in one tick.
 */
-__stk_forceinline int32_t GetTickResolution()
+__stk_forceinline uint32_t GetTickResolution()
 {
     return IKernelService::GetInstance()->GetTickResolution();
 }
@@ -295,11 +306,12 @@ __stk_forceinline Ticks GetTicksFromMs(Time ms)
 */
 static inline Time GetTimeNowMs()
 {
-    IKernelService *service = IKernelService::GetInstance();
-    int32_t resolution = service->GetTickResolution();
-    Ticks ticks = service->GetTicks();
+    const IKernelService *const service = IKernelService::GetInstance();
+    const uint32_t resolution = service->GetTickResolution();
+    const Ticks tick_count = service->GetTicks();
 
-    return ((resolution == 1000) ? ticks : ((ticks * resolution) / 1000));
+    return ((resolution == 1000U) ? tick_count : 
+        ((tick_count * static_cast<Ticks>(resolution)) / static_cast<Ticks>(1000)));
 }
 
 /*! \brief     Get system timer count value.
@@ -323,12 +335,12 @@ __stk_forceinline uint32_t GetSysTimerFrequency()
 /*! \brief     Put calling process into a sleep state.
     \note      Unlike Delay this function does not waste CPU cycles and allows kernel to put CPU into a low-power state.
     \note      Unsupported in HRT mode (see stk::KERNEL_HRT); in HRT mode tasks sleep automatically according to their periodicity and workload.
-    \param[in] ticks: Sleep time (ticks). 0 does not cause yield, use Yield instead. Negative will cause an assertion.
+    \param[in] tick_count: Sleep time (in ticks). 0 does not cause yield, use Yield instead. Negative will cause an assertion.
     \warning   ISR-unsafe. Calling from an ISR context is not permitted and will trigger an assertion.
 */
-__stk_forceinline void Sleep(Timeout ticks)
+__stk_forceinline void Sleep(Timeout tick_count)
 {
-    IKernelService::GetInstance()->Sleep(ticks);
+    IKernelService::GetInstance()->Sleep(tick_count);
 }
 
 /*! \brief     Put calling process into a sleep state.
@@ -341,7 +353,8 @@ __stk_forceinline void Sleep(Timeout ticks)
 */
 static inline void SleepMs(Timeout ms)
 {
-    Sleep(static_cast<Timeout>(GetTicksFromMs(ms)));
+    const Ticks tick_count = GetTicksFromMs(static_cast<Time>(ms));
+    Sleep(static_cast<Timeout>(tick_count < WAIT_INFINITE ? tick_count : WAIT_INFINITE));
 }
 
 /*! \brief     Put calling process into a sleep state until the specified timestamp.
@@ -378,12 +391,12 @@ __stk_forceinline void Yield()
 /*! \brief     Delay calling process by busy-waiting until the deadline expires.
     \note      Unlike Sleep this function delays code execution by spinning in a loop until deadline expiry.
     \note      Use with care in HRT mode to avoid missed deadline (see stk::KERNEL_HRT, ITask::OnDeadlineMissed).
-    \param[in] ticks: Delay time (ticks). Negative will cause an assertion.
+    \param[in] tick_count: Delay time (in ticks). Negative will cause an assertion.
     \warning   ISR-unsafe. Calling from an ISR context is not permitted and will trigger an assertion.
 */
-__stk_forceinline void Delay(Timeout ticks)
+__stk_forceinline void Delay(Timeout tick_count)
 {
-    IKernelService::GetInstance()->Delay(ticks);
+    IKernelService::GetInstance()->Delay(tick_count);
 }
 
 /*! \brief     Delay calling process by busy-waiting until the deadline expires.
@@ -394,7 +407,8 @@ __stk_forceinline void Delay(Timeout ticks)
 */
 static inline void DelayMs(Timeout ms)
 {
-    Delay(static_cast<Timeout>(GetTicksFromMs(ms)));
+    const Ticks tick_count = GetTicksFromMs(static_cast<Time>(ms));
+    Delay(static_cast<Timeout>(tick_count < WAIT_INFINITE ? tick_count : WAIT_INFINITE));
 }
 
 } // namespace stk

--- a/stk/include/stk_linked_list.h
+++ b/stk/include/stk_linked_list.h
@@ -14,14 +14,14 @@
     \brief Intrusive doubly-linked list implementation used internally by the kernel.
 
     Provides two class templates:
-     - DListEntry<T, _ClosedLoop>: the node embedded inside a host object (T).
-     - DListHead<T, _ClosedLoop>:  the list container that owns and traverses the nodes.
+     - DListEntry<T, TClosedLoop>: the node embedded inside a host object (T).
+     - DListHead<T, TClosedLoop>:  the list container that owns and traverses the nodes.
 
     The list is \e intrusive: the link pointers live inside the host object itself,
     so no separate heap allocation is required for list membership.
     A single host object may belong to at most one list at a time.
 
-    The \c _ClosedLoop template parameter selects between two structural variants:
+    The \c TClosedLoop template parameter selects between two structural variants:
      - \c false: open (linear) list — first->prev and last->next are \c NULL.
      - \c true:  closed (circular) list — first->prev points to last and
                  last->next points to first, enabling O(1) wrap-around traversal.
@@ -32,18 +32,18 @@ namespace util {
 
 // Forward declaration required so DListEntry can reference DListHead as a friend
 // and store a back-pointer to the owning list head.
-template <class T, bool _ClosedLoop> class DListHead;
+template <class T, bool TClosedLoop> class DListHead;
 
 /*! \class DListEntry
     \brief Intrusive doubly-linked list node. Embed this as a base class in any object (T)
            that needs to participate in a DListHead list.
 
-    \tparam T:         The host class that derives from DListEntry. Used by the implicit
+    \tparam T:           The host class that derives from DListEntry. Used by the implicit
                          conversion operators to safely downcast the node pointer back to the
                          host object pointer without a dynamic_cast.
-    \tparam _ClosedLoop: When \c true the list is kept circular (last->next == first and
+    \tparam TClosedLoop: When \c true the list is kept circular (last->next == first and
                          first->prev == last). When \c false the list is linear (boundary
-                         pointers are \c NULL). Must match the \c _ClosedLoop of the
+                         pointers are \c NULL). Must match the \c TClosedLoop of the
                          DListHead this entry will be inserted into.
 
     \note  An entry that is not currently in any list has \c m_head == \c NULL.
@@ -54,9 +54,9 @@ template <class T, bool _ClosedLoop> class DListHead;
     \note  Not thread-safe. The caller is responsible for protecting list operations
            with a hw::CriticalSection or equivalent.
 */
-template <class T, bool _ClosedLoop> class DListEntry
+template <class T, bool TClosedLoop> class DListEntry
 {
-    friend class DListHead<T, _ClosedLoop>;
+    friend class DListHead<T, TClosedLoop>;
 
 public:
     /*! \brief Construct an unlinked entry. All pointers initialized to NULL.
@@ -67,12 +67,12 @@ public:
     /*! \typedef DLEntryType
         \brief   Convenience alias for this entry type. Used to avoid repeating the full template spelling.
     */
-    typedef DListEntry<T, _ClosedLoop> DLEntryType;
+    typedef DListEntry<T, TClosedLoop> DLEntryType;
 
     /*! \typedef DLHeadType
         \brief   Convenience alias for the corresponding list head type.
     */
-    typedef DListHead<T, _ClosedLoop>  DLHeadType;
+    typedef DListHead<T, TClosedLoop>  DLHeadType;
 
     /*! \brief  Get the list head this entry currently belongs to.
         \return Pointer to the owning DListHead, or \c NULL if the entry is not linked.
@@ -87,7 +87,7 @@ public:
     /*! \brief  Get the next entry in the list.
         \return Pointer to the next DListEntry, or \c NULL if this is the last entry
                 (open list) or the first entry (closed loop, where next wraps to first).
-        \note   In a closed loop (\c _ClosedLoop == true) this pointer is never \c NULL
+        \note   In a closed loop (\c TClosedLoop == true) this pointer is never \c NULL
                 when the entry is linked.
     */
     DLEntryType *GetNext() { return m_next; }
@@ -95,7 +95,7 @@ public:
     /*! \brief  Get the next entry in the list.
         \return Pointer to the next DListEntry, or \c NULL if this is the last entry
                 (open list) or the first entry (closed loop, where next wraps to first).
-        \note   In a closed loop (\c _ClosedLoop == true) this pointer is never \c NULL
+        \note   In a closed loop (\c TClosedLoop == true) this pointer is never \c NULL
                 when the entry is linked.
     */
     const DLEntryType *GetNext() const { return m_next; }
@@ -103,7 +103,7 @@ public:
     /*! \brief  Get the previous entry in the list.
         \return Pointer to the previous DListEntry, or \c NULL if this is the first entry
                 (open list) or the last entry (closed loop, where prev wraps to last).
-        \note   In a closed loop (\c _ClosedLoop == true) this pointer is never \c NULL
+        \note   In a closed loop (\c TClosedLoop == true) this pointer is never \c NULL
                 when the entry is linked.
     */
     DLEntryType *GetPrev() { return m_prev; }
@@ -111,7 +111,7 @@ public:
     /*! \brief  Get the previous entry in the list.
         \return Pointer to the previous DListEntry, or \c NULL if this is the first entry
                 (open list) or the last entry (closed loop, where prev wraps to last).
-        \note   In a closed loop (\c _ClosedLoop == true) this pointer is never \c NULL
+        \note   In a closed loop (\c TClosedLoop == true) this pointer is never \c NULL
                 when the entry is linked.
     */
     const DLEntryType *GetPrev() const { return m_prev; }
@@ -122,14 +122,14 @@ public:
     bool IsLinked() const { return (GetHead() != nullptr); }
 
     /*! \brief Implicit conversion to a mutable pointer to the host object (T).
-        \note  Safe because T must derive from DListEntry<T, _ClosedLoop>.
+        \note  Safe because T must derive from DListEntry<T, TClosedLoop>.
                Eliminates the need for explicit static_cast at call sites.
         \note  MISRA deviation: [STK-DEV-004] Rule 5-2-x.
     */
     operator T *() { return static_cast<T *>(this); }
 
     /*! \brief Implicit conversion to a const pointer to the host object (T).
-        \note  Safe because T must derive from DListEntry<T, _ClosedLoop>.
+        \note  Safe because T must derive from DListEntry<T, TClosedLoop>.
                Eliminates the need for explicit static_cast at call sites.
         \note  MISRA deviation: [STK-DEV-004] Rule 5-2-x.
     */
@@ -144,8 +144,7 @@ protected:
         \note      An entry should be removed from its list (via DListHead::Unlink) before the
                    host object is destroyed, to keep the list's neighbour pointers consistent.
     */
-    ~DListEntry()
-    {}
+    ~DListEntry() = default;
 
 private:
     /*! \brief     Wire this entry into a list between \a prev and \a next.
@@ -162,10 +161,14 @@ private:
         m_prev = prev;
 
         if (m_prev != nullptr)
+        {
             m_prev->m_next = this;
+        }
 
         if (m_next != nullptr)
+        {
             m_next->m_prev = this;
+        }
     }
 
     /*! \brief  Remove this entry from its current list.
@@ -178,10 +181,14 @@ private:
     void Unlink()
     {
         if (m_prev != nullptr)
+        {
             m_prev->m_next = m_next;
+        }
 
         if (m_next != nullptr)
+        {
             m_next->m_prev = m_prev;
+        }
 
         m_head = nullptr;
         m_next = nullptr;
@@ -198,8 +205,8 @@ private:
            embedded in host objects of type T.
 
     \tparam T:         The host class whose instances are stored in this list. Each T must
-                         derive from DListEntry<T, _ClosedLoop>.
-    \tparam _ClosedLoop: When \c true the list is maintained as a circular ring: after every
+                         derive from DListEntry<T, TClosedLoop>.
+    \tparam TClosedLoop: When \c true the list is maintained as a circular ring: after every
                          insertion or removal, last->next is set to first and first->prev is
                          set to last. This allows scheduler algorithms to wrap around the end
                          of the list in O(1) without a branch. When \c false the boundary
@@ -213,19 +220,19 @@ private:
     \note  Not thread-safe. The caller is responsible for protecting concurrent access with
            a hw::CriticalSection or equivalent.
 */
-template <class T, bool _ClosedLoop> class DListHead
+template <class T, bool TClosedLoop> class DListHead
 {
-    friend class DListEntry<T, _ClosedLoop>;
+    friend class DListEntry<T, TClosedLoop>;
 
 public:
     /*! \typedef DLEntryType
         \brief   Convenience alias for the node type stored in this list.
     */
-    typedef DListEntry<T, _ClosedLoop> DLEntryType;
+    typedef DListEntry<T, TClosedLoop> DLEntryType;
 
     /*! \brief Construct an empty list head (count = 0, first = last = NULL).
     */
-    explicit DListHead(): m_count(0), m_first(nullptr), m_last(nullptr)
+    explicit DListHead(): m_count(0U), m_first(nullptr), m_last(nullptr)
     {}
 
     /*! \brief  Get the number of entries currently in the list.
@@ -236,7 +243,7 @@ public:
     /*! \brief  Check whether the list contains no entries.
         \return \c true if empty; \c false otherwise.
     */
-    bool IsEmpty() const { return (m_count == 0); }
+    bool IsEmpty() const { return (m_count == 0U); }
 
     /*! \brief  Get the first (front) entry without removing it.
         \return Pointer to the first DListEntry, or \c NULL if the list is empty.
@@ -322,10 +329,14 @@ public:
         STK_ASSERT(entry->GetHead() == this);
 
         if (m_first == entry)
+        {
             m_first = entry->GetNext();
+        }
 
         if (m_last == entry)
+        {
             m_last = entry->GetPrev();
+        }
 
         entry->Unlink();
         --m_count;
@@ -364,19 +375,43 @@ public:
         STK_ASSERT(!entry->IsLinked());
 
         if (prev == nullptr)
+        {
             next = m_first;
+        }
 
         ++m_count;
         entry->Link(this, next, prev);
-
-        if ((m_first == nullptr) || (m_first == entry->GetNext()))
+        
+        if (m_first == nullptr)
+        {
             m_first = entry;
+        }
+        else if (m_first == entry->GetNext())
+        {
+            m_first = entry;
+        }        
+        else
+        {
+            // noop
+        }
 
-        if ((m_last == nullptr) || (m_last == entry->GetPrev()))
+        if (m_last == nullptr)
+        {
             m_last = entry;
+        }
+        else if (m_last == entry->GetPrev())
+        {
+            m_last = entry;
+        }
+        else
+        {
+            // noop
+        }
 
-        if (_ClosedLoop)
+        if __stk_constexpr_cpp17 (TClosedLoop)
+        {
             UpdateEnds();
+        }
     }
 
 private:
@@ -384,10 +419,10 @@ private:
         \note   Called after every insertion and removal. Two responsibilities:
                 1. If the list is now empty, resets m_first and m_last to \c NULL so
                    the head is in a canonical empty state.
-                2. If \c _ClosedLoop is \c true and the list is non-empty, sets
+                2. If \c TClosedLoop is \c true and the list is non-empty, sets
                    \c m_last->m_next = m_first and \c m_first->m_prev = m_last to
                    maintain the circular invariant.
-        \note   For open lists (\c _ClosedLoop == false) only the empty-list reset runs;
+        \note   For open lists (\c TClosedLoop == false) only the empty-list reset runs;
                 the branch is eliminated at compile time by the constant template parameter.
     */
     void UpdateEnds()
@@ -397,11 +432,13 @@ private:
             m_first = nullptr;
             m_last  = nullptr;
         }
-        else
-        if (_ClosedLoop)
+        else 
         {
-            m_first->m_prev = m_last;
-            m_last->m_next = m_first;
+            if __stk_constexpr_cpp17 (TClosedLoop)
+            {
+                m_first->m_prev = m_last;
+                m_last->m_next  = m_first;
+            }
         }
     }
 

--- a/stk/include/strategy/stk_strategy_edf.h
+++ b/stk/include/strategy/stk_strategy_edf.h
@@ -79,7 +79,7 @@ public:
     /*! \brief Destructor.
         \note  MISRA deviation: [STK-DEV-005] Rule 10-3-2.
     */
-    ~SwitchStrategyEDF() = default;
+    STK_VIRT_DTOR ~SwitchStrategyEDF() = default;
 
     /*! \brief     Add task to the runnable set.
         \param[in] task: Task to add. Must not be \c NULL and must not already be in any list.
@@ -110,9 +110,13 @@ public:
         STK_ASSERT((task->GetHead() == &m_tasks) || (task->GetHead() == &m_sleep));
 
         if (task->GetHead() == &m_tasks)
+        {
             m_tasks.Unlink(task);
+        }
         else
+        {
             m_sleep.Unlink(task);
+        }
     }
 
     /*! \brief     Select and return the task with the earliest (minimum) relative deadline.
@@ -133,20 +137,28 @@ public:
     */
     IKernelTask *GetNext() override
     {
-        if (m_tasks.IsEmpty())
-            return nullptr; // idle
+        IKernelTask *next = nullptr;
 
-        IKernelTask *itr = (*m_tasks.GetFirst()), * const start = itr;
-        IKernelTask *earliest = itr;
-
-        do
+        if (!m_tasks.IsEmpty())
         {
-            if (itr->GetHrtRelativeDeadline() < earliest->GetHrtRelativeDeadline())
-                earliest = itr;
-        }
-        while ((itr = (*itr->GetNext())) != start);
+            IKernelTask *itr = (*m_tasks.GetFirst());
+            IKernelTask *const start = itr;
+            
+            next = itr; // initialize earliest found task to the first one
 
-        return earliest;
+            do
+            {
+                if (itr->GetHrtRelativeDeadline() < next->GetHrtRelativeDeadline())
+                {
+                    next = itr;
+                }
+                  
+                itr = (*itr->GetNext());
+            }
+            while (itr != start);
+        }
+
+        return next;
     }
 
     /*! \brief     Get first task in the managed set (used by the kernel for initial scheduling).
@@ -160,10 +172,9 @@ public:
     {
         STK_ASSERT(GetSize() != 0U);
 
-        if (!m_tasks.IsEmpty())
-            return (*const_cast<IKernelTask::ListEntryType *>(m_tasks.GetFirst()));
-        else
-            return (*const_cast<IKernelTask::ListEntryType *>(m_sleep.GetFirst()));
+        return (!m_tasks.IsEmpty() ?
+            (*const_cast<IKernelTask::ListEntryType *>(m_tasks.GetFirst())) :
+            (*const_cast<IKernelTask::ListEntryType *>(m_sleep.GetFirst())));
     }
 
     /*! \brief  Get total number of tasks managed by this strategy.

--- a/stk/include/strategy/stk_strategy_fpriority.h
+++ b/stk/include/strategy/stk_strategy_fpriority.h
@@ -100,7 +100,7 @@ public:
     /*! \brief Destructor.
         \note  MISRA deviation: [STK-DEV-005] Rule 10-3-2.
     */
-    ~SwitchStrategyFixedPriority() = default;
+    STK_VIRT_DTOR ~SwitchStrategyFixedPriority() = default;
 
     /*! \brief     Add task to the runnable set at its fixed priority level.
         \param[in] task: Task to add. Must not be \c NULL and must not already be in any list.
@@ -121,14 +121,15 @@ public:
         STK_ASSERT(GetTaskPriority(task) < MAX_PRIORITIES);
 
         const Priority prio = GetTaskPriority(task);
-
-        bool is_tail = (m_prev[prio] == m_tasks[prio].GetLast());
+        const bool is_tail = (m_prev[prio] == m_tasks[prio].GetLast());
 
         AddActive(task);
 
         // if pointer was pointing to the tail, become a tail
         if (is_tail)
+        {
             m_prev[prio] = task;
+        }
     }
 
     /*! \brief     Remove task from whichever list it currently occupies.
@@ -146,9 +147,13 @@ public:
         STK_ASSERT((task->GetHead() == &m_tasks[GetTaskPriority(task)]) || (task->GetHead() == &m_sleep));
 
         if (task->GetHead() == &m_sleep)
+        {
             m_sleep.Unlink(task);
+        }
         else
+        {
             RemoveActive(task, GetTaskPriority(task));
+        }
     }
 
     /*! \brief     Select and return the next task to run.
@@ -162,15 +167,17 @@ public:
     */
     IKernelTask *GetNext() override
     {
-        if (m_ready_bitmap == 0U)
-            return nullptr; // idle
+        IKernelTask *next = nullptr;
 
-        const Priority prio = GetHighestReadyPriority(m_ready_bitmap);
+        if (m_ready_bitmap != 0U)
+        {
+            const Priority prio = GetHighestReadyPriority(m_ready_bitmap);
 
-        IKernelTask *ret = (*m_prev[prio]->GetNext());
-        m_prev[prio] = ret;
+            next = (*m_prev[prio]->GetNext());
+            m_prev[prio] = next;
+        }
 
-        return ret;
+        return next;
     }
 
     /*! \brief     Get the first task in the managed set (used by the kernel for initial scheduling).
@@ -185,11 +192,19 @@ public:
     {
         STK_ASSERT(GetSize() != 0U);
 
-        if (m_ready_bitmap == 0U)
-            return (*const_cast<IKernelTask::ListEntryType *>(m_sleep.GetFirst()));
+        IKernelTask *first_task = nullptr;
 
-        const Priority prio = GetHighestReadyPriority(m_ready_bitmap);
-        return (*const_cast<IKernelTask::ListEntryType *>(m_tasks[prio].GetFirst()));
+        if (m_ready_bitmap == 0U)
+        {
+            first_task = (*const_cast<IKernelTask::ListEntryType *>(m_sleep.GetFirst()));
+        }
+        else
+        {
+            const Priority prio = GetHighestReadyPriority(m_ready_bitmap);
+            first_task = (*const_cast<IKernelTask::ListEntryType *>(m_tasks[prio].GetFirst()));
+        }
+
+        return first_task;
     }
 
     /*! \brief  Get the total number of tasks managed by this strategy.
@@ -200,8 +215,10 @@ public:
     size_t GetSize() const override
     {
         size_t total = m_sleep.GetSize();
-        for (Priority i = 0U; i < MAX_PRIORITIES; i += 1U)
+        for (Priority i = 0U; i < MAX_PRIORITIES; ++i)
+        {
             total += m_tasks[i].GetSize();
+        }
 
         return total;
     }
@@ -365,7 +382,9 @@ protected:
         for (int8_t i = 31; i >= 0; --i)
         {
             if (bitmap & (1U << i))
+            {
                 return GetTaskPriorityFromWeight(i);
+            }
         }
         return 0;
     #endif

--- a/stk/include/strategy/stk_strategy_monotonic.h
+++ b/stk/include/strategy/stk_strategy_monotonic.h
@@ -33,9 +33,9 @@ enum EMonotonicSwitchStrategyType
 
 /*! \class SwitchStrategyMonotonic
     \brief Monotonic scheduling strategy: Rate-Monotonic (RM) or Deadline-Monotonic (DM),
-           selected at compile time by the \a _Type template parameter.
+           selected at compile time by the \a TStrategyType template parameter.
 
-    \tparam _Type: Policy selector (EMonotonicSwitchStrategyType):
+    \tparam TStrategyType: Policy selector (EMonotonicSwitchStrategyType):
                    - \c MSS_TYPE_RATE     - Rate-Monotonic: tasks with a \e shorter scheduling
                      period receive higher priority. The most frequently activating task always
                      runs first.
@@ -65,7 +65,7 @@ enum EMonotonicSwitchStrategyType
            SchedulabilityCheck::IsSchedulableWCRT().
     \see   SwitchStrategyRM, SwitchStrategyDM, SchedulabilityCheck, ITaskSwitchStrategy
 */
-template <EMonotonicSwitchStrategyType _Type>
+template <EMonotonicSwitchStrategyType TStrategyType>
 class SwitchStrategyMonotonic final : public ITaskSwitchStrategy
 {
 public:
@@ -88,12 +88,12 @@ public:
     /*! \brief Destructor.
         \note  MISRA deviation: [STK-DEV-005] Rule 10-3-2.
     */
-    ~SwitchStrategyMonotonic() = default;
+    STK_VIRT_DTOR ~SwitchStrategyMonotonic() = default;
 
     /*! \brief     Add a task to the priority-sorted runnable list.
         \param[in] task: Task to add. Must not be \c NULL and must not already be in any list.
         \note      Performs an O(n) insertion sort into \c m_tasks so that higher-priority tasks
-                   appear closer to the head. The sort key depends on \a _Type:
+                   appear closer to the head. The sort key depends on \a TStrategyType:
                    - \c MSS_TYPE_RATE:     key = GetHrtPeriodicity() (smaller -> nearer to head).
                    - \c MSS_TYPE_DEADLINE: key = GetHrtDeadline()    (smaller -> nearer to head).
         \note      Three insertion cases handled:
@@ -117,12 +117,12 @@ public:
         }
         else
         {
-            IKernelTask *itr = (*m_tasks.GetFirst()), * const start = itr;
+            IKernelTask *itr = (*m_tasks.GetFirst()), *const start = itr;
 
             for (;;)
             {
-                bool higher_priority;
-                switch (_Type)
+                bool higher_priority = false;
+                switch (TStrategyType)
                 {
                 case MSS_TYPE_RATE:
                     higher_priority = (task->GetHrtPeriodicity() < itr->GetHrtPeriodicity());
@@ -148,7 +148,8 @@ public:
                 }
 
                 // end of the list
-                if ((itr = (*itr->GetNext())) == start)
+                itr = (*itr->GetNext());
+                if (itr == start)
                 {
                     m_tasks.LinkBack(task);
                     break;
@@ -180,27 +181,29 @@ public:
                    IsSleeping() returns \c false is always the highest-priority runnable task.
                    Complexity is O(k) where k is the number of sleeping tasks at the front of
                    the list (i.e. higher-priority tasks currently between activations).
-        \note      Asserts if \c m_tasks is empty; at least one task must be registered before
-                   GetNext() is called.
     */
     IKernelTask *GetNext() override
     {
-        STK_ASSERT(!m_tasks.IsEmpty());
-
-        IKernelTask *itr = (*m_tasks.GetFirst()), * const start = itr;
         IKernelTask *next = nullptr;
 
-        // Scan from head (highest priority). Skip tasks that are sleeping between
-        // periodic activations; return the first task ready to run.
-        do
+        if (!m_tasks.IsEmpty())
         {
-            if (!itr->IsSleeping())
+            IKernelTask *itr = (*m_tasks.GetFirst()), *const start = itr;
+
+            // scan from head (highest priority); skip tasks that are sleeping between
+            // periodic activations; return the first task ready to run
+            do
             {
-                next = itr;
-                break; // list is sorted by priority; no need to continue
+                if (!itr->IsSleeping())
+                {
+                    next = itr;
+                    break; // list is sorted by priority; no need to continue
+                }
+
+                itr = (*itr->GetNext());
             }
+            while (itr != start);
         }
-        while ((itr = (*itr->GetNext())) != start);
 
         // nullptr means all tasks are sleeping, return idle signal to kernel
         return next;
@@ -311,7 +314,7 @@ public:
     /*! \class SchedulabilityCheckResult
         \brief Result of a WCRT schedulability test: overall verdict plus per-task details.
 
-        The number of tasks is fixed at compile time through the \a _TaskCount template
+        The number of tasks is fixed at compile time through the \a TTaskCount template
         parameter, which must equal the number of tasks registered with the kernel strategy.
         Array indices match the priority-sorted task order: index 0 = highest-priority task.
 
@@ -323,11 +326,11 @@ public:
         STK_ASSERT(result); // assert all tasks meet their deadlines
         \endcode
     */
-    template <uint32_t _TaskCount>
+    template <uint32_t TTaskCount>
     struct SchedulabilityCheckResult
     {
         bool     schedulable;      //!< \c true if every task's WCRT <= its period (T); \c false if any task misses its deadline.
-        TaskInfo info[_TaskCount]; //!< Per-task analysis results, ordered highest priority first (index 0 = highest priority task).
+        TaskInfo info[TTaskCount]; //!< Per-task analysis results, ordered highest priority first (index 0 = highest priority task).
 
         /*! \brief  Check whether the full task set is schedulable.
             \return \c true if all tasks meet their deadlines; \c false otherwise.
@@ -336,49 +339,51 @@ public:
     };
 
     /*! \brief               Perform WCRT schedulability analysis on the task set registered with \a strategy.
-        \tparam _TaskCount:  Number of tasks to analyse. Must equal the number of tasks currently
-                             registered with \a strategy (asserted at runtime: idx == _TaskCount).
+        \tparam TTaskCount:  Number of tasks to analyse. Must equal the number of tasks currently
+                             registered with \a strategy (asserted at runtime: idx == TTaskCount).
         \param[in] strategy: Pointer to the monotonic scheduling strategy whose task list is analysed.
                              Must not be \c nullptr and must have at least one task registered.
-        \return              A SchedulabilityCheckResult<_TaskCount> containing the schedulability
+        \return              A SchedulabilityCheckResult<TTaskCount> containing the schedulability
                              verdict and per-task CPU load and WCRT values.
         \note                Tasks are read from the strategy's sorted \c m_tasks list in priority
                              order (index 0 = highest priority). For each task, \c period is
                              populated from GetHrtPeriodicity() and \c duration from GetHrtDeadline()
                              before invoking GetTaskCpuLoad() and CalculateWCRT().
      */
-    template <uint32_t _TaskCount>
-    static inline SchedulabilityCheckResult<_TaskCount> IsSchedulableWCRT(const ITaskSwitchStrategy *strategy)
+    template <uint32_t TTaskCount>
+    static inline SchedulabilityCheckResult<TTaskCount> IsSchedulableWCRT(const ITaskSwitchStrategy *strategy)
     {
         STK_ASSERT(strategy != nullptr);
         STK_ASSERT(strategy->GetFirst() != nullptr);
 
-        const IKernelTask::ListHeadType *ktasks = strategy->GetFirst()->GetHead();
+        const IKernelTask::ListHeadType *const ktasks = strategy->GetFirst()->GetHead();
 
         STK_ASSERT(ktasks != nullptr);
-        STK_ASSERT(ktasks->GetSize() <= _TaskCount);
+        STK_ASSERT(ktasks->GetSize() <= TTaskCount);
 
-        SchedulabilityCheckResult<_TaskCount> ret;
-        TaskTiming tasks[_TaskCount];
+        SchedulabilityCheckResult<TTaskCount> ret;
+        TaskTiming tasks[TTaskCount];
 
         // fill tasks timing
         const IKernelTask *itr = (*ktasks->GetFirst()), * const start = itr;
         uint32_t idx = 0U;
         do
         {
-            STK_ASSERT(idx < _TaskCount);
+            STK_ASSERT(idx < TTaskCount);
             tasks[idx].period   = static_cast<uint32_t>(itr->GetHrtPeriodicity());
             tasks[idx].duration = static_cast<uint32_t>(itr->GetHrtDeadline());
             idx += 1U;
+            
+            itr = (*itr->GetNext());
         }
-        while ((itr = (*itr->GetNext())) != start);
-        STK_ASSERT(idx == _TaskCount);
+        while (itr != start);
+        STK_ASSERT(idx == TTaskCount);
 
         // calculate CPU load
-        GetTaskCpuLoad(tasks, _TaskCount, ret.info);
+        GetTaskCpuLoad(tasks, TTaskCount, ret.info);
 
         // run the WCRT schedulability analysis
-        ret.schedulable = CalculateWCRT(tasks, _TaskCount, ret.info);
+        ret.schedulable = CalculateWCRT(tasks, TTaskCount, ret.info);
 
         return ret;
     }
@@ -409,29 +414,33 @@ public:
        The highest-priority task (index 0) has no higher-priority interference; its WCRT
        is set directly to its own WCET (\c tasks[0].duration) without iteration.
 
-       \param[in]  tasks: Array of TaskTiming in descending priority order (index 0 = highest).
+       \param[in]  task_array: Array of TaskTiming in descending priority order (index 0 = highest).
        \param[in]  count: Number of tasks in \a tasks.
-       \param[out] info:  Array of TaskInfo of size \a count. \c info[i].wcrt receives the
-                         computed WCRT for task \e i on return.
+       \param[out] info_array: Array of TaskInfo of size \a count. \c info[i].wcrt receives the
+                   computed WCRT for task \e i on return.
        \return     \c true if every task's WCRT <= its period (Tx); \c false if any task misses.
      */
-    static inline bool CalculateWCRT(const TaskTiming *tasks, const uint32_t count, TaskInfo *info)
+    static inline bool CalculateWCRT(const TaskTiming *task_array, const uint32_t count, TaskInfo *info_array)
     {
         bool schedulable = true;
+        ArrayView<const TaskTiming> tasks(task_array, count);
+        ArrayView<TaskInfo> info(info_array, count);
         info[0].wcrt = tasks[0].duration;
 
-        for (uint32_t t = 1; t < count; )
+        for (uint32_t t = 1U; t < tasks.GetSize(); )
         {
-            uint32_t w,
-            Cx = tasks[t].duration,
-            Tx = tasks[t].period,
-            w0 = Cx;
+            uint32_t       w  = 0U;
+            const uint32_t Cx = tasks[t].duration;
+            const uint32_t Tx = tasks[t].period;
+            uint32_t       w0 = Cx;
 
         next_itr:
 
             w = Cx;
-            for (uint32_t i = 0; i < t; ++i)
+            for (uint32_t i = 0U; i < t; ++i)
+            {
                 w += idiv_ceil(w0, tasks[i].period) * tasks[i].duration;
+            }
 
             if ((w != w0) && (w <= Tx))
             {
@@ -458,25 +467,39 @@ public:
     */
     static inline void GetTaskCpuLoad(const TaskTiming *tasks, const uint32_t count, TaskInfo *info)
     {
-        uint16_t total = 0;
+        uint16_t total = 0U;
 
-        for (uint32_t t = 0; t < count; ++t)
+        for (uint32_t i = 0U; i < count; ++i)
         {
-            uint16_t task_load = (uint16_t)(tasks[t].duration * 100 / tasks[t].period);
+            const uint16_t task_load = static_cast<uint16_t>(tasks[i].duration * 100U / tasks[i].period);
             total += task_load;
 
-            info[t].cpu_load.task  = task_load;
-            info[t].cpu_load.total = total;
+            info[i].cpu_load.task  = task_load;
+            info[i].cpu_load.total = total;
         }
     }
 
 private:
-    //! Integer ceiling division: returns ceil(x / y) = x/y + (x%y > 0 ? 1 : 0).
-    //! Equivalent to (int32_t)ceil((float)x / y) but exact and branch-free for integers.
-    //! Reference: http://stackoverflow.com/questions/2745074/fast-ceiling-of-an-integer-division-in-c-c
-    static __stk_forceinline int32_t idiv_ceil(uint32_t x, uint32_t y)
+    /*! \brief      Compute the ceiling of an integer division: ceil(x / y).
+        \param[in]  x: Dividend (numerator).
+        \param[in]  y: Divisor (denominator).
+        \return     The result of the ceiling division, or 0 if \a y is 0.
+    */
+    static inline uint32_t idiv_ceil(uint32_t x, uint32_t y)
     {
-        return ((y != 0) ? (x / y + (x % y > 0)) : 0);
+        uint32_t result = 0U;
+
+        if (y != 0U)
+        {
+            result = x / y;
+            
+            if ((x % y) > 0U)
+            {
+                result++;
+            }
+        }
+
+        return result;
     }
 };
 

--- a/stk/include/strategy/stk_strategy_rrobin.h
+++ b/stk/include/strategy/stk_strategy_rrobin.h
@@ -60,7 +60,7 @@ public:
     /*! \brief Destructor.
         \note  MISRA deviation: [STK-DEV-005] Rule 10-3-2.
     */
-    ~SwitchStrategyRoundRobin() = default;
+    STK_VIRT_DTOR ~SwitchStrategyRoundRobin() = default;
 
     /*! \brief     Add task to the runnable set.
         \param[in] task: Task to add. Must not be \c nullptr and must not already be in any list.
@@ -74,13 +74,15 @@ public:
         STK_ASSERT(task != nullptr);
         STK_ASSERT(task->GetHead() == nullptr);
 
-        bool tail = (m_prev == m_tasks.GetLast());
+        const bool tail = (m_prev == m_tasks.GetLast());
 
         m_tasks.LinkBack(task);
 
         // if pointer was pointing to the tail, become a tail
         if (tail)
+        {
             m_prev = task;
+        }
     }
 
     /*! \brief     Remove task from whichever list it currently occupies.
@@ -96,9 +98,13 @@ public:
         STK_ASSERT((task->GetHead() == &m_tasks) || (task->GetHead() == &m_sleep));
 
         if (task->GetHead() == &m_tasks)
+        {
             RemoveActive(task);
+        }
         else
+        {
             m_sleep.Unlink(task);
+        }
     }
 
     /*! \brief     Advance cursor and return the next runnable task.
@@ -112,15 +118,15 @@ public:
     */
     IKernelTask *GetNext() override
     {
-        IKernelTask *ret = m_prev;
+        IKernelTask *next = m_prev;
 
-        if (ret != nullptr)
+        if (next != nullptr)
         {
-            ret    = (*ret->GetNext());
-            m_prev = ret;
+            next    = (*next->GetNext());
+            m_prev = next;
         }
 
-        return ret;
+        return next;
     }
 
     /*! \brief     Get first task in the managed set (used by the kernel for initial scheduling).
@@ -133,10 +139,9 @@ public:
     {
         STK_ASSERT(GetSize() != 0U);
 
-        if (!m_tasks.IsEmpty())
-            return (*const_cast<IKernelTask::ListEntryType *>(m_tasks.GetFirst()));
-        else
-            return (*const_cast<IKernelTask::ListEntryType *>(m_sleep.GetFirst()));
+        return (!m_tasks.IsEmpty() ?
+            (*const_cast<IKernelTask::ListEntryType *>(m_tasks.GetFirst())) :
+            (*const_cast<IKernelTask::ListEntryType *>(m_sleep.GetFirst())));
     }
 
     /*! \brief  Get total number of tasks managed by this strategy.
@@ -194,7 +199,9 @@ protected:
         // update pointer: if all tasks were sleeping, this task will change state
         // of the kernel to active
         if (m_prev == nullptr)
+        {
             m_prev = task;
+        }
     }
 
     /*! \brief     Remove a task from \c m_tasks and update the cursor.
@@ -211,7 +218,7 @@ protected:
     */
     void RemoveActive(IKernelTask *task)
     {
-        IKernelTask *next = (*task->GetNext());
+        IKernelTask *const next = (*task->GetNext());
 
         m_tasks.Unlink(task);
 
@@ -219,9 +226,13 @@ protected:
         // if there are no tasks left GetNext() will return nullptr causing a sleep
         // state for the kernel
         if (next != task)
+        {
             m_prev = (*next->GetPrev());
+        }
         else
+        {
             m_prev = nullptr;
+        }
     }
 
     IKernelTask::ListHeadType m_tasks; //!< Runnable tasks eligible for scheduling.

--- a/stk/include/strategy/stk_strategy_swrrobin.h
+++ b/stk/include/strategy/stk_strategy_swrrobin.h
@@ -81,7 +81,7 @@ public:
     /*! \brief Destructor.
         \note  MISRA deviation: [STK-DEV-005] Rule 10-3-2.
     */
-    ~SwitchStrategySmoothWeightedRoundRobin() = default;
+    STK_VIRT_DTOR ~SwitchStrategySmoothWeightedRoundRobin() = default;
 
     /*! \brief     Add task to the runnable set.
         \param[in] task: Task to add. Must not be \c nullptr.
@@ -118,9 +118,13 @@ public:
         STK_ASSERT((task->GetHead() == &m_tasks) || (task->GetHead() == &m_sleep));
 
         if (task->GetHead() == &m_tasks)
+        {
             RemoveActive(task);
+        }
         else
+        {
             m_sleep.Unlink(task);
+        }
     }
 
     /*! \brief     Select and return the next task to run, applying one step of the SWRR algorithm.
@@ -137,31 +141,35 @@ public:
     */
     IKernelTask *GetNext() override
     {
-        if (m_tasks.IsEmpty())
-            return nullptr; // idle
+        IKernelTask *next = nullptr;
 
-        IKernelTask *selected = nullptr;
-        int32_t max_weight = INT32_MIN;
-        IKernelTask *itr = (*m_tasks.GetFirst()), * const start = itr;
-
-        do
+        if (!m_tasks.IsEmpty())
         {
-            const int32_t candidate_weight = itr->GetCurrentWeight() + itr->GetWeight();
-            itr->SetCurrentWeight(candidate_weight);
+            int32_t max_weight = INT32_MIN;
+            IKernelTask *itr = (*m_tasks.GetFirst());
+            IKernelTask *const start = itr;
 
-            if (candidate_weight > max_weight)
+            do
             {
-                max_weight = candidate_weight;
-                selected = itr;
+                const int32_t candidate_weight = itr->GetCurrentWeight() + itr->GetWeight();
+                itr->SetCurrentWeight(candidate_weight);
+
+                if (candidate_weight > max_weight)
+                {
+                    max_weight = candidate_weight;
+                    next = itr;
+                }
+                
+                itr = (*itr->GetNext());
             }
+            while (itr != start);
+
+            STK_ASSERT(next != nullptr);
+
+            next->SetCurrentWeight(max_weight - m_total_weight);
         }
-        while ((itr = (*itr->GetNext())) != start);
 
-        STK_ASSERT(selected != nullptr);
-
-        selected->SetCurrentWeight(max_weight - m_total_weight);
-
-        return selected;
+        return next;
     }
 
     /*! \brief     Get first task in the managed set (used by the kernel for initial scheduling).
@@ -174,10 +182,9 @@ public:
     {
         STK_ASSERT(GetSize() != 0U);
 
-        if (!m_tasks.IsEmpty())
-            return (*const_cast<IKernelTask::ListEntryType *>(m_tasks.GetFirst()));
-        else
-            return (*const_cast<IKernelTask::ListEntryType *>(m_sleep.GetFirst()));
+        return (!m_tasks.IsEmpty() ?
+            (*const_cast<IKernelTask::ListEntryType *>(m_tasks.GetFirst())) :
+            (*const_cast<IKernelTask::ListEntryType *>(m_sleep.GetFirst())));
     }
 
     /*! \brief  Get the total number of tasks managed by this strategy.

--- a/stk/include/sync/stk_sync_cs.h
+++ b/stk/include/sync/stk_sync_cs.h
@@ -68,7 +68,7 @@ public:
     /*! \brief Exits critical section.
         \note  MISRA deviation: [STK-DEV-005] Rule 10-3-2.
     */
-    ~ScopedCriticalSection() { Unlock(); }
+    STK_VIRT_DTOR ~ScopedCriticalSection() { Unlock(); }
 
 private:
     STK_NONCOPYABLE_CLASS(ScopedCriticalSection);

--- a/stk/include/sync/stk_sync_cv.h
+++ b/stk/include/sync/stk_sync_cv.h
@@ -75,7 +75,7 @@ public:
                    (dangling waiters). An assertion is triggered in debug builds.
         \note      MISRA deviation: [STK-DEV-005] Rule 10-3-2.
     */
-    ~ConditionVariable()
+    STK_VIRT_DTOR  ~ConditionVariable()
     {
         STK_ASSERT(m_wait_list.IsEmpty()); // API contract: must not be destroyed with waiting tasks
     }
@@ -87,12 +87,12 @@ public:
         \param[in] mutex: An \a IMutex-compatible lock that must be held by the calling task
                    before Wait() is called. The kernel releases it atomically during suspension
                    and re-acquires it on wake.
-        \param[in] timeout: Maximum time to wait (ticks). Use \a WAIT_INFINITE to block
+        \param[in] timeout_ticks: Maximum time to wait (ticks). Use \a WAIT_INFINITE to block
                    indefinitely, \a NO_WAIT to return immediately without blocking.
         \return    \c true if signaled, \c false if timeout occurred or \a NO_WAIT was passed.
-        \warning   ISR-safe only with timeout=NO_WAIT, ISR-unsafe otherwise.
+        \warning   ISR-safe only with timeout_ticks=NO_WAIT, ISR-unsafe otherwise.
     */
-    bool Wait(IMutex &mutex, Timeout timeout = WAIT_INFINITE);
+    bool Wait(IMutex &mutex, Timeout timeout_ticks = WAIT_INFINITE);
 
     /*! \brief     Wake one waiting task.
         \note      ISR-safe.
@@ -124,17 +124,20 @@ private:
 // Wait
 // ---------------------------------------------------------------------------
 
-inline bool ConditionVariable::Wait(IMutex &mutex, Timeout timeout)
+inline bool ConditionVariable::Wait(IMutex &mutex, Timeout timeout_ticks)
 {
     // API contract: mutex must be locked by the calling task before Wait() is called.
     // The kernel releases it atomically during suspension and re-acquires it on wake.
+    bool success = false;
 
-    if (timeout == NO_WAIT)
-        return false;
+    if (timeout_ticks != NO_WAIT)
+    {
+        STK_ASSERT(!hw::IsInsideISR()); // API contract: caller must not be in ISR if timeout_ticks!=NO_WAIT
+        
+        success = !IKernelService::GetInstance()->Wait(this, &mutex, timeout_ticks)->IsTimeout();
+    }
 
-    STK_ASSERT(!hw::IsInsideISR()); // API contract: caller must not be in ISR if timeout!=NO_WAIT
-
-    return !IKernelService::GetInstance()->Wait(this, &mutex, timeout)->IsTimeout();
+    return success;
 }
 
 // ---------------------------------------------------------------------------
@@ -143,7 +146,7 @@ inline bool ConditionVariable::Wait(IMutex &mutex, Timeout timeout)
 
 inline void ConditionVariable::NotifyOne()
 {
-    ScopedCriticalSection cs_;
+    const ScopedCriticalSection cs_;
     NotifyOne_CS();
 }
 
@@ -162,7 +165,7 @@ inline void ConditionVariable::NotifyOne_CS()
 
 inline void ConditionVariable::NotifyAll()
 {
-    ScopedCriticalSection cs_;
+    const ScopedCriticalSection cs_;
     NotifyAll_CS(); // wakes all tasks in the wait list simultaneously
 }
 

--- a/stk/include/sync/stk_sync_event.h
+++ b/stk/include/sync/stk_sync_event.h
@@ -58,7 +58,7 @@ namespace sync {
     \see  ISyncObject, IWaitObject, IKernelService::Wait
     \note Only available when kernel is compiled with \a KERNEL_SYNC mode enabled.
 */
-class Event final : public ITraceable, private ISyncObject
+class Event final : private ISyncObject, public ITraceable
 {
 public:
     /*! \brief     Constructor.
@@ -75,7 +75,7 @@ public:
                    (dangling waiters). An assertion is triggered in debug builds.
         \note      MISRA deviation: [STK-DEV-005] Rule 10-3-2.
     */
-    ~Event()
+    STK_VIRT_DTOR ~Event()
     {
         STK_ASSERT(m_wait_list.IsEmpty()); // API contract: must not be destroyed with waiting tasks
     }
@@ -103,12 +103,12 @@ public:
     bool Reset();
 
     /*! \brief     Wait until event becomes signaled or the timeout expires.
-        \param[in] timeout: Maximum time to wait (ticks). Use \a WAIT_INFINITE for no timeout (wait forever).
-        \warning   ISR-safe only with \a timeout = \c NO_WAIT, ISR-unsafe otherwise.
+        \param[in] timeout_ticks: Maximum time to wait (ticks). Use \a WAIT_INFINITE for no timeout (wait forever).
+        \warning   ISR-safe only with \a timeout_ticks = \c NO_WAIT, ISR-unsafe otherwise.
         \return    \c true if event was signaled (wait succeeded),
                    \c false if timeout occurred before the event was signaled.
     */
-    bool Wait(Timeout timeout = WAIT_INFINITE);
+    bool Wait(Timeout timeout_ticks = WAIT_INFINITE);
 
     /*! \brief    Poll event state without blocking.
         \details  Checks if the event is currently signaled. If signaled, performs the auto-reset
@@ -146,20 +146,29 @@ private:
 
 inline bool Event::Set()
 {
-    ScopedCriticalSection cs_;
+    const ScopedCriticalSection cs_;
+    bool status = true;
 
     if (m_signaled)
-        return false;
-
-    m_signaled = true;
-    __stk_full_memfence();
-
-    if (m_manual_reset)
-        WakeAll();
+    {
+        status = false;
+    }
     else
-        WakeOne(); // auto-reset is applied in RemoveWaitObject when the waiter is removed
+    {
+        m_signaled = true;
+        __stk_full_memfence();
 
-    return true;
+        if (m_manual_reset)
+        {
+            WakeAll();
+        }
+        else
+        {
+            WakeOne(); // auto-reset is applied in RemoveWaitObject when the waiter is removed
+        }
+    }
+
+    return status;
 }
 
 // ---------------------------------------------------------------------------
@@ -168,9 +177,9 @@ inline bool Event::Set()
 
 inline bool Event::Reset()
 {
-    ScopedCriticalSection cs_;
+    const ScopedCriticalSection cs_;
 
-    bool prev = m_signaled;
+    const bool prev = m_signaled;
 
     m_signaled = false;
     __stk_full_memfence();
@@ -184,7 +193,7 @@ inline bool Event::Reset()
 
 inline void Event::Pulse()
 {
-    ScopedCriticalSection cs_;
+    const ScopedCriticalSection cs_;
 
     // transition to signaled so that WakeOne/WakeAll can release waiters:
     // m_signaled is only visible as true while this critical section is held —
@@ -196,9 +205,13 @@ inline void Event::Pulse()
     if (!m_wait_list.IsEmpty())
     {
         if (m_manual_reset)
+        {
             WakeAll();
+        }
         else
+        {
             WakeOne(); // auto-reset applied in RemoveWaitObject
+        }
     }
 
     // force return to non-signaled regardless of whether anyone was waiting
@@ -210,11 +223,12 @@ inline void Event::Pulse()
 // Wait
 // ---------------------------------------------------------------------------
 
-inline bool Event::Wait(Timeout timeout)
+inline bool Event::Wait(Timeout timeout_ticks)
 {
     STK_ASSERT(!hw::IsInsideISR()); // API contract: caller must not be in ISR
 
     ScopedCriticalSection cs_;
+    bool success = false;
 
     // fast path: already signaled
     if (m_signaled)
@@ -225,15 +239,20 @@ inline bool Event::Wait(Timeout timeout)
             __stk_full_memfence();
         }
 
-        return true;
+        success = true;
+    }
+    // slow path: block until Set() signals the event or timeout expires
+    else if (timeout_ticks != NO_WAIT)
+    {
+        success = !IKernelService::GetInstance()->Wait(this, &cs_, timeout_ticks)->IsTimeout();
+    }
+    else
+    {
+        // non-blocking poll: event not signaled, return immediately
+        // success is already false, so noop
     }
 
-    // non-blocking poll: event not signaled, return immediately
-    if (timeout == NO_WAIT)
-        return false;
-
-    // slow path: block until Set() signals the event or timeout expires
-    return !IKernelService::GetInstance()->Wait(this, &cs_, timeout)->IsTimeout();
+    return success;
 }
 
 // ---------------------------------------------------------------------------
@@ -242,7 +261,8 @@ inline bool Event::Wait(Timeout timeout)
 
 inline bool Event::TryWait()
 {
-    ScopedCriticalSection cs_;
+    const ScopedCriticalSection cs_;
+    bool result = false;
 
     if (m_signaled)
     {
@@ -252,10 +272,10 @@ inline bool Event::TryWait()
             __stk_full_memfence();
         }
 
-        return true;
+        result = true;
     }
 
-    return false;
+    return result;
 }
 
 // ---------------------------------------------------------------------------
@@ -269,10 +289,13 @@ inline void Event::RemoveWaitObject(IWaitObject *wobj)
     // kernel invariant: auto-reset is applied here, not at the Set()/Pulse() call site,
     // when a task wakes due to a signal (not a timeout), the event transitions back to
     // non-signaled so that subsequent Wait() calls block until the next Set().
-    if (!m_manual_reset && m_signaled && !wobj->IsTimeout())
+    if (!m_manual_reset && m_signaled)
     {
-        m_signaled = false;
-        __stk_full_memfence();
+        if (!wobj->IsTimeout())
+        {
+            m_signaled = false;
+            __stk_full_memfence();
+        }
     }
 }
 

--- a/stk/include/sync/stk_sync_eventflags.h
+++ b/stk/include/sync/stk_sync_eventflags.h
@@ -132,11 +132,7 @@ public:
                    (dangling waiters). An assertion is triggered in debug builds.
         \note      MISRA deviation: [STK-DEV-005] Rule 10-3-2.
     */
-    ~EventFlags()
-    {
-        // API contract: must not be destroyed while tasks are waiting
-        // (checked inside Mutex/ConditionVariable destructors via their own assertions)
-    }
+    STK_VIRT_DTOR ~EventFlags() = default;
 
     // -----------------------------------------------------------------------
     // Flag manipulation
@@ -185,7 +181,7 @@ public:
                    not have bit 31 set.
         \param[in] options: Combination of \c WAIT_ANY / \c WAIT_ALL and optionally
                    \c NO_CLEAR. Default: \c WAIT_ANY (clear on success).
-        \param[in] timeout: Maximum time to wait (ticks).
+        \param[in] timeout_ticks: Maximum time to wait (ticks).
                    Use \c WAIT_INFINITE to block indefinitely,
                    \c NO_WAIT for a non-blocking poll.
         \return    Bitmask of the flags that caused the wakeup (the matched subset),
@@ -194,9 +190,9 @@ public:
         \note      If the predicate becomes satisfied in the same tick that the deadline
                    expires, the wait succeeds and returns the matched flags. The timeout
                    is only reported when the condition is not met at deadline time.
-        \warning   ISR-safe only with \a timeout = \c NO_WAIT, ISR-unsafe otherwise.
+        \warning   ISR-safe only with \a timeout_ticks = \c NO_WAIT, ISR-unsafe otherwise.
     */
-    uint32_t Wait(uint32_t flags, uint32_t options = OPT_WAIT_ANY, Timeout timeout = WAIT_INFINITE);
+    uint32_t Wait(uint32_t flags, uint32_t options = OPT_WAIT_ANY, Timeout timeout_ticks = WAIT_INFINITE);
 
     /*! \brief     Non-blocking flag poll.
         \details   Checks immediately whether the flag condition is satisfied.
@@ -218,10 +214,8 @@ private:
     // Must be called with m_mutex held.
     bool IsSatisfied(uint32_t flags, uint32_t options) const
     {
-        if (options & OPT_WAIT_ALL)
-            return ((m_flags & flags) == flags);
-        else
-            return ((m_flags & flags) != 0U);
+        return ((options & OPT_WAIT_ALL) == OPT_WAIT_ALL) ? ((m_flags & flags) == flags) :
+            ((m_flags & flags) != 0U);
     }
 
     volatile uint32_t m_flags; //!< 32-bit flags word (bit 31 is reserved for errors)
@@ -234,18 +228,20 @@ private:
 
 inline uint32_t EventFlags::Set(uint32_t flags)
 {
-    if ((flags == 0U) || ((flags & ERROR_MASK) != 0U))
-        return ERROR_PARAMETER;
+    uint32_t final_result = ERROR_PARAMETER;
 
-    ScopedCriticalSection cs_;
+    if ((flags != 0U) && ((flags & ERROR_MASK) == 0U))
+    {
+        const ScopedCriticalSection cs_;
 
-    m_flags |= flags;
-    const uint32_t result = m_flags;
+        m_flags |= flags;
+        final_result = m_flags;
 
-    // wake all waiters: each task will re-evaluate its own predicate
-    m_cv.NotifyAll();
+        // wake all waiters: each task will re-evaluate its own predicate
+        m_cv.NotifyAll();
+    }
 
-    return result;
+    return final_result;
 }
 
 // ---------------------------------------------------------------------------
@@ -254,15 +250,17 @@ inline uint32_t EventFlags::Set(uint32_t flags)
 
 inline uint32_t EventFlags::Clear(uint32_t flags)
 {
-    if ((flags == 0U) || ((flags & ERROR_MASK) != 0U))
-        return ERROR_PARAMETER;
+    uint32_t result = ERROR_PARAMETER;
 
-    ScopedCriticalSection cs_;
+    if ((flags != 0U) && ((flags & ERROR_MASK) == 0U))
+    {
+        const ScopedCriticalSection cs_;
 
-    const uint32_t prev = m_flags;
-    m_flags &= ~flags;
+        result = m_flags;
+        m_flags &= ~flags;
+    }
 
-    return prev;
+    return result;
 }
 
 // ---------------------------------------------------------------------------
@@ -280,50 +278,65 @@ inline uint32_t EventFlags::Get() const
 // Wait
 // ---------------------------------------------------------------------------
 
-inline uint32_t EventFlags::Wait(uint32_t flags, uint32_t options, Timeout timeout)
+inline uint32_t EventFlags::Wait(uint32_t flags, uint32_t options, Timeout timeout_ticks)
 {
+    uint32_t final_result = 0U;
+
     // validate: flags must be non-zero and must not have the error sentinel bit set
     if ((flags == 0U) || ((flags & ERROR_MASK) != 0U))
-        return ERROR_PARAMETER;
-
-    // ISR check: only NO_WAIT is permitted inside an ISR
-    if (hw::IsInsideISR() && (timeout != NO_WAIT))
-        return ERROR_ISR;
-
-    const bool timed_wait = (timeout != WAIT_INFINITE) && (timeout != NO_WAIT);
-
-    // capture an absolute deadline once, before entering the wait loop,
-    // this prevents the timeout from being silently restarted on each
-    // spurious wakeup (e.g. a partial Set() that does not satisfy WAIT_ALL)
-    const Timeout deadline = (timed_wait ? static_cast<Timeout>(GetTicks() + timeout) : timeout);
-
-    ScopedCriticalSection cs_;
-
-    // spin (with blocking) until the predicate is satisfied or we time out
-    while (!IsSatisfied(flags, options))
     {
-        Timeout remaining = deadline;
-        if (timed_wait)
+        final_result = ERROR_PARAMETER;
+    }
+    // ISR check: only NO_WAIT is permitted inside an ISR
+    else if (hw::IsInsideISR() && (timeout_ticks != NO_WAIT))
+    {
+        final_result = ERROR_ISR;
+    }
+    else
+    {
+        const bool timed_wait = (timeout_ticks != WAIT_INFINITE) && (timeout_ticks != NO_WAIT);
+
+        // capture an absolute deadline once, before entering the wait loop,
+        // this prevents the timeout from being silently restarted on each
+        // spurious wakeup (e.g. a partial Set() that does not satisfy WAIT_ALL)
+        const Timeout deadline = (timed_wait ? 
+            static_cast<Timeout>(GetTicks() + timeout_ticks) : timeout_ticks);
+
+        ScopedCriticalSection cs_;
+
+        // spin (with blocking) until the predicate is satisfied or we time out
+        while (!IsSatisfied(flags, options))
         {
-            const Timeout now = static_cast<Timeout>(GetTicks());
-            remaining = (now >= deadline ? NO_WAIT : (deadline - now));
+            Timeout remaining = deadline;
+            if (timed_wait)
+            {
+                const Timeout now = static_cast<Timeout>(GetTicks());
+                remaining = (now >= deadline ? NO_WAIT : (deadline - now));
+            }
+
+            if (!m_cv.Wait(cs_, remaining))
+            {
+                // timeout: mark failure and flag the loop to terminate
+                final_result = ERROR_TIMEOUT;
+                break;
+            }
         }
 
-        if (!m_cv.Wait(cs_, remaining))
+        // If we didn't time out, the predicate was satisfied successfully
+        if (final_result != ERROR_TIMEOUT)
         {
-            // timeout: release the mutex and report failure
-            return ERROR_TIMEOUT;
+            // predicate satisfied: determine which flags matched
+            final_result = (((options & OPT_WAIT_ALL) == OPT_WAIT_ALL) ? flags : (m_flags & flags));
+
+            // atomically clear the matched flags unless the caller opted out
+            if ((options & OPT_NO_CLEAR) == 0U)
+            {
+                m_flags &= ~final_result;
+            }
         }
     }
 
-    // predicate satisfied: determine which flags matched
-    const uint32_t matched = (options & OPT_WAIT_ALL ? flags : (m_flags & flags));
-
-    // atomically clear the matched flags unless the caller opted out
-    if ((options & OPT_NO_CLEAR) == 0U)
-        m_flags &= ~matched;
-
-    return matched;
+    return final_result;
 }
 
 } // namespace sync

--- a/stk/include/sync/stk_sync_msgqueue.h
+++ b/stk/include/sync/stk_sync_msgqueue.h
@@ -10,8 +10,6 @@
 #ifndef STK_SYNC_MSGQUEUE_H_
 #define STK_SYNC_MSGQUEUE_H_
 
-#include <cstring> // for memcpy
-
 #include "stk_sync_cv.h"
 
 /*! \file  stk_sync_msgqueue.h
@@ -75,7 +73,7 @@ public:
                    ConditionVariable destructors.
         \note      MISRA deviation: [STK-DEV-005] Rule 10-3-2.
     */
-    ~MessageQueue() = default;
+    STK_VIRT_DTOR ~MessageQueue() = default;
 
     /*! \brief     Put a message into the back of the queue (FIFO order).
         \details   Copies \a msg_size bytes from \a msg_ptr into the next available
@@ -83,14 +81,14 @@ public:
                    is suspended until space becomes available or the timeout
                    expires.
         \param[in] msg_ptr: Pointer to the message payload (must be at least \a msg_size bytes).
-        \param[in] timeout: Maximum time to wait for a free slot (ticks).
+        \param[in] timeout_ticks: Maximum time to wait for a free slot (ticks).
                    Use \c WAIT_INFINITE to block indefinitely, \c NO_WAIT for a
                    non-blocking attempt.
-        \warning   ISR-safe only with \a timeout = \c NO_WAIT, ISR-unsafe otherwise.
+        \warning   ISR-safe only with \a timeout_ticks = \c NO_WAIT, ISR-unsafe otherwise.
         \return    \c true if the message was successfully enqueued,
                    \c false if the timeout expired before space became available.
     */
-    bool Put(const void *msg_ptr, Timeout timeout = WAIT_INFINITE);
+    bool Put(const void *msg_ptr, Timeout timeout_ticks = WAIT_INFINITE);
 
     /*! \brief     Attempt to put a message into the back of the queue without blocking.
         \details   Enqueues the message only if a free slot is immediately
@@ -108,15 +106,15 @@ public:
                    \c Get() will return. If the queue is full the calling task is
                    suspended until space becomes available or the timeout expires.
         \param[in] msg_ptr: Pointer to the message payload (must be at least \a msg_size bytes).
-        \param[in] timeout: Maximum time to wait for a free slot (ticks).
+        \param[in] timeout_ticks: Maximum time to wait for a free slot (ticks).
                    Use \c WAIT_INFINITE to block indefinitely, \c NO_WAIT for a
                    non-blocking attempt.
-        \warning   ISR-safe only with \a timeout = \c NO_WAIT, ISR-unsafe otherwise.
+        \warning   ISR-safe only with \a timeout_ticks = \c NO_WAIT, ISR-unsafe otherwise.
         \return    \c true if the message was successfully enqueued at the front,
                    \c false if the timeout expired before space became available.
         \see       Put, TryPutFront
     */
-    bool PutFront(const void *msg_ptr, Timeout timeout = WAIT_INFINITE);
+    bool PutFront(const void *msg_ptr, Timeout timeout_ticks = WAIT_INFINITE);
 
     /*! \brief     Attempt to put a message into the front of the queue without blocking.
         \details   Enqueues the message at the front only if a free slot is immediately
@@ -136,14 +134,14 @@ public:
                    produced or the timeout expires.
         \param[out] msg_ptr: Destination buffer for the retrieved message
                     (must be at least \a msg_size bytes).
-        \param[in]  timeout: Maximum time to wait for a message (ticks).
+        \param[in]  timeout_ticks: Maximum time to wait for a message (ticks).
                     Use \c WAIT_INFINITE to block indefinitely, \c NO_WAIT for a
                     non-blocking attempt.
-        \warning    ISR-safe only with \a timeout = \c NO_WAIT, ISR-unsafe otherwise.
+        \warning    ISR-safe only with \a timeout_ticks = \c NO_WAIT, ISR-unsafe otherwise.
         \return     \c true if a message was successfully retrieved,
                     \c false if the timeout expired before a message was available.
     */
-    bool Get(void *msg_ptr, Timeout timeout = WAIT_INFINITE);
+    bool Get(void *msg_ptr, Timeout timeout_ticks = WAIT_INFINITE);
 
     /*! \brief     Attempt to get a message from the queue without blocking.
         \details   Dequeues a message only if one is immediately available.
@@ -163,15 +161,15 @@ public:
                    is produced or the timeout expires.
         \param[out] msg_ptr: Destination buffer for the peeked message
                     (must be at least \a msg_size bytes).
-        \param[in]  timeout: Maximum time to wait for a message (ticks).
+        \param[in]  timeout_ticks: Maximum time to wait for a message (ticks).
                     Use \c WAIT_INFINITE to block indefinitely, \c NO_WAIT for a
                     non-blocking attempt.
-        \warning    ISR-safe only with \a timeout = \c NO_WAIT, ISR-unsafe otherwise.
+        \warning    ISR-safe only with \a timeout_ticks = \c NO_WAIT, ISR-unsafe otherwise.
         \return     \c true if a message was successfully peeked,
                     \c false if the timeout expired before a message was available.
         \see        Get, TryPeek, PeekFront
     */
-    bool Peek(void *msg_ptr, Timeout timeout = WAIT_INFINITE);
+    bool Peek(void *msg_ptr, Timeout timeout_ticks = WAIT_INFINITE);
 
     /*! \brief     Attempt to peek at the next message without blocking.
         \details   Copies the oldest message into \a msg_ptr only if one is
@@ -192,15 +190,15 @@ public:
                    suspended until a message is produced or the timeout expires.
         \param[out] msg_ptr: Destination buffer for the peeked message
                     (must be at least \a msg_size bytes).
-        \param[in]  timeout: Maximum time to wait for a message (ticks).
+        \param[in]  timeout_ticks: Maximum time to wait for a message (ticks).
                     Use \c WAIT_INFINITE to block indefinitely, \c NO_WAIT for a
                     non-blocking attempt.
-        \warning    ISR-safe only with \a timeout = \c NO_WAIT, ISR-unsafe otherwise.
+        \warning    ISR-safe only with \a timeout_ticks= \c NO_WAIT, ISR-unsafe otherwise.
         \return     \c true if a message was successfully peeked,
                     \c false if the timeout expired before a message was available.
         \see        PutFront, TryPeekFront, Peek
     */
-    bool PeekFront(void *msg_ptr, Timeout timeout = WAIT_INFINITE);
+    bool PeekFront(void *msg_ptr, Timeout timeout_ticks = WAIT_INFINITE);
 
     /*! \brief     Attempt to peek at the front message without blocking.
         \details   Copies the most recently front-inserted message into \a msg_ptr
@@ -321,127 +319,162 @@ inline MessageQueue::MessageQueue(uint8_t *buf, size_t capacity, size_t msg_size
 // Put
 // ---------------------------------------------------------------------------
 
-inline bool MessageQueue::Put(const void *msg_ptr, Timeout timeout)
+inline bool MessageQueue::Put(const void *msg_ptr, Timeout timeout_ticks)
 {
     STK_ASSERT(msg_ptr != nullptr);             // API contract: msg_ptr must not be null
     STK_ASSERT(m_count <= (CAPACITY_MAX - 1U)); // API contract: must not exceed capacity
 
     ScopedCriticalSection cs_;
+    bool success = true;
 
     while (m_count == m_capacity)
     {
-        if (!m_cv_not_full.Wait(cs_, timeout))
-            return false;
+        if (!m_cv_not_full.Wait(cs_, timeout_ticks))
+        {
+            success = false;
+            break;
+        }
     }
 
-    STK_MEMCPY(Slot(m_head), msg_ptr, m_msg_size);
-    m_head = Next(m_head);
-    m_count++;
+    if (success)
+    {
+        STK_MEMCPY(Slot(m_head), msg_ptr, m_msg_size);
+        m_head = Next(m_head);
+        m_count++;
 
-    m_cv_not_empty.NotifyOne_CS();
+        m_cv_not_empty.NotifyOne_CS();
+    }
 
-    return true;
+    return success;
 }
 
 // ---------------------------------------------------------------------------
 // PutFront
 // ---------------------------------------------------------------------------
 
-inline bool MessageQueue::PutFront(const void *msg_ptr, Timeout timeout)
+inline bool MessageQueue::PutFront(const void *msg_ptr, Timeout timeout_ticks)
 {
     STK_ASSERT(msg_ptr != nullptr);             // API contract: msg_ptr must not be null
     STK_ASSERT(m_count <= (CAPACITY_MAX - 1U)); // API contract: must not exceed capacity
 
     ScopedCriticalSection cs_;
+    bool success = true;
 
     while (m_count == m_capacity)
     {
-        if (!m_cv_not_full.Wait(cs_, timeout))
-            return false;
+        if (!m_cv_not_full.Wait(cs_, timeout_ticks))
+        {
+            success = false;
+            break;
+        }
     }
 
-    // Retreat the tail pointer to claim the slot that Get() would read next,
-    // then write the message there.  This makes the new message the head of
-    // the logical sequence without touching m_head at all.
-    m_tail = Prev(m_tail);
-    STK_MEMCPY(Slot(m_tail), msg_ptr, m_msg_size);
-    m_count++;
+    if (success)
+    {
+        // retreat the tail pointer to claim the slot that Get() would read next,
+        // then write the message there; this makes the new message the head of
+        // the logical sequence without touching m_head at all
+        m_tail = Prev(m_tail);
+        STK_MEMCPY(Slot(m_tail), msg_ptr, m_msg_size);
+        m_count++;
 
-    m_cv_not_empty.NotifyOne_CS();
+        m_cv_not_empty.NotifyOne_CS();
+    }
 
-    return true;
+    return success;
 }
 
 // ---------------------------------------------------------------------------
 // Get
 // ---------------------------------------------------------------------------
 
-inline bool MessageQueue::Get(void *msg_ptr, Timeout timeout)
+inline bool MessageQueue::Get(void *msg_ptr, Timeout timeout_ticks)
 {
     STK_ASSERT(msg_ptr != nullptr); // API contract: msg_ptr must not be null
 
     ScopedCriticalSection cs_;
+    bool success = true;
 
     while (m_count == 0U)
     {
-        if (!m_cv_not_empty.Wait(cs_, timeout))
-            return false;
+        if (!m_cv_not_empty.Wait(cs_, timeout_ticks))
+        {
+            success = false;
+            break;
+        }
     }
 
-    memcpy(msg_ptr, Slot(m_tail), m_msg_size);
-    m_tail = Next(m_tail);
-    m_count--;
+    if (success)
+    {
+        STK_MEMCPY(msg_ptr, Slot(m_tail), m_msg_size);
+        m_tail = Next(m_tail);
+        m_count--;
 
-    m_cv_not_full.NotifyOne_CS();
+        m_cv_not_full.NotifyOne_CS();
+    }
 
-    return true;
+    return success;
 }
 
 // ---------------------------------------------------------------------------
 // Peek
 // ---------------------------------------------------------------------------
 
-inline bool MessageQueue::Peek(void *msg_ptr, Timeout timeout)
+inline bool MessageQueue::Peek(void *msg_ptr, Timeout timeout_ticks)
 {
     STK_ASSERT(msg_ptr != nullptr); // API contract: msg_ptr must not be null
 
     ScopedCriticalSection cs_;
+    bool success = true;
 
     while (m_count == 0U)
     {
-        if (!m_cv_not_empty.Wait(cs_, timeout))
-            return false;
+        if (!m_cv_not_empty.Wait(cs_, timeout_ticks))
+        {
+            success = false;
+            break;
+        }
     }
 
-    // Copy from the tail slot without advancing the index or decrementing
-    // the count, so the message remains available for the next Get().
-    STK_MEMCPY(msg_ptr, Slot(m_tail), m_msg_size);
+    if (success)
+    {
+        // copy from the tail slot without advancing the index or decrementing
+        // the count, so the message remains available for the next Get()
+        STK_MEMCPY(msg_ptr, Slot(m_tail), m_msg_size);
+    }
 
-    return true;
+    return success;
 }
 
 // ---------------------------------------------------------------------------
 // PeekFront
 // ---------------------------------------------------------------------------
 
-inline bool MessageQueue::PeekFront(void *msg_ptr, Timeout timeout)
+inline bool MessageQueue::PeekFront(void *msg_ptr, Timeout timeout_ticks)
 {
     STK_ASSERT(msg_ptr != nullptr); // API contract: msg_ptr must not be null
 
     ScopedCriticalSection cs_;
+    bool success = true;
 
     while (m_count == 0U)
     {
-        if (!m_cv_not_empty.Wait(cs_, timeout))
-            return false;
+        if (!m_cv_not_empty.Wait(cs_, timeout_ticks))
+        {
+            success = false;
+            break;
+        }
     }
 
-    // The front-inserted message is at m_tail (PutFront retreats m_tail then
-    // writes, so the newly placed message is always at the current m_tail).
-    // For a pure-Put queue this is equally correct: m_tail is the oldest slot.
-    STK_MEMCPY(msg_ptr, Slot(m_tail), m_msg_size);
+    if (success)
+    {
+        // the front-inserted message is at m_tail (PutFront retreats m_tail then
+        // writes, so the newly placed message is always at the current m_tail);
+        // for a pure-Put queue this is equally correct: m_tail is the oldest slot
+        STK_MEMCPY(msg_ptr, Slot(m_tail), m_msg_size);
+    }
 
-    return true;
+    return success;
 }
 
 // ---------------------------------------------------------------------------
@@ -450,13 +483,13 @@ inline bool MessageQueue::PeekFront(void *msg_ptr, Timeout timeout)
 
 inline void MessageQueue::Reset()
 {
-    ScopedCriticalSection cs_;
+    const ScopedCriticalSection cs_;
 
     m_count = 0U;
     m_head  = 0U;
     m_tail  = 0U;
 
-    // Wake all blocked producers: the queue is now entirely empty.
+    // wake all blocked producers: the queue is now entirely empty
     m_cv_not_full.NotifyAll_CS();
 }
 
@@ -517,7 +550,7 @@ public:
                    ConditionVariable destructors.
         \note      MISRA deviation: [STK-DEV-005] Rule 10-3-2.
     */
-    ~MessageQueueT() = default;
+    STK_VIRT_DTOR ~MessageQueueT() = default;
 
 private:
     STK_NONCOPYABLE_CLASS(MessageQueueT);

--- a/stk/include/sync/stk_sync_mutex.h
+++ b/stk/include/sync/stk_sync_mutex.h
@@ -51,7 +51,7 @@ namespace sync {
     \note Only available when kernel is compiled with \a KERNEL_SYNC mode enabled.
     \see  ISyncObject, IWaitObject, IKernelService::Wait
 */
-class Mutex final : public IMutex, public ITraceable, private ISyncObject
+class Mutex final : private ISyncObject, public IMutex, public ITraceable
 {
 public:
     /*! \brief     Constructor.
@@ -64,18 +64,18 @@ public:
                    An assertion is triggered in debug builds.
         \note      MISRA deviation: [STK-DEV-005] Rule 10-3-2.
     */
-    ~Mutex()
+    STK_VIRT_DTOR ~Mutex()
     {
         STK_ASSERT(m_wait_list.IsEmpty()); // API contract: must not be destroyed with waiting tasks
     }
 
     /*! \brief     Acquire lock.
-        \param[in] timeout: Maximum time to wait (ticks).
+        \param[in] timeout_ticks: Maximum time to wait (ticks).
         \note      Maximum number of recursive locks must not exceed 0xFFFEU.
-        \warning   ISR-safe only with \a timeout = \c NO_WAIT, ISR-unsafe otherwise.
+        \warning   ISR-safe only with \a timeout_ticks = \c NO_WAIT, ISR-unsafe otherwise.
         \return    True if lock acquired, false if timeout occurred.
     */
-    bool TimedLock(Timeout timeout);
+    bool TimedLock(Timeout timeout_ticks);
 
     /*! \brief     Acquire lock.
         \warning   ISR-unsafe.
@@ -111,66 +111,80 @@ private:
 // TimedLock
 // ---------------------------------------------------------------------------
 
-inline bool Mutex::TimedLock(Timeout timeout)
+inline bool Mutex::TimedLock(Timeout timeout_ticks)
 {
-    IKernelService *svc = IKernelService::GetInstance();
-    TId current_tid = svc->GetTid();
+    IKernelService *const svc = IKernelService::GetInstance();
+    const TId current_tid = svc->GetTid();
 
     ScopedCriticalSection cs_;
 
     const TId owner_tid = m_owner_tid;
+    bool success = false;
 
-    // already owned by the calling thread (recursive path)
+    // recursive path: already owned by the calling thread
     if ((m_recursion_count != 0U) && (owner_tid == current_tid))
     {
         STK_ASSERT(m_recursion_count < RECURSION_MAX); // API contract: caller must not exceed max recursion depth
 
         m_recursion_count = static_cast<uint16_t>(m_recursion_count + 1U);
-        return true;
+        success = true;
     }
-
-    // mutex is free (fast path)
-    if (m_recursion_count == 0U)
+    // fast path: mutex is free
+    else if (m_recursion_count == 0U)
     {
         // kernel invariant: counter is zero so owner must be TID_NONE
         if (owner_tid != TID_NONE)
+        {
             STK_KERNEL_PANIC(KERNEL_PANIC_ASSERT);
+        }
 
         m_recursion_count = 1U;
         m_owner_tid       = current_tid;
         __stk_full_memfence();
 
-        return true;
+        success = true;
     }
-
-    // try lock behavior
-    if (timeout == NO_WAIT)
-        return false;
-
-    STK_ASSERT(!hw::IsInsideISR()); // API contract: caller must not be in ISR for a blocking call
-
-    // boost priority of the owner to avoid priority inversion (in case of SwitchStrategyFixedPriority,
-    // otherwise ignored by the kernel), noop if ISwitchStrategy::PRIORITY_INHERITANCE_API = 0
-    svc->InheritWeight(owner_tid, GetUserTaskFromTid(current_tid)->GetWeight());
-
-    // mutex owned by another thread (slow path/blocking)
-    if (svc->Wait(this, &cs_, timeout)->IsTimeout())
+    // slow path: block until available or timeout expires
+    else if (timeout_ticks != NO_WAIT)
     {
-        // if owner did not change, undo priority boost to avoid stuck elevated priority: lookup for a
-        // higher weight within existing wait objects, noop if ISwitchStrategy::PRIORITY_INHERITANCE_API = 0
-        if (owner_tid == m_owner_tid)
-            svc->RestoreWeight(owner_tid, this);
+        STK_ASSERT(!hw::IsInsideISR()); // API contract: caller must not be in ISR for a blocking call
 
-        return false;
+        // boost priority of the owner to avoid priority inversion (in case of SwitchStrategyFixedPriority,
+        // otherwise ignored by the kernel), noop if ISwitchStrategy::PRIORITY_INHERITANCE_API = 0
+        svc->InheritWeight(owner_tid, GetUserTaskFromTid(current_tid)->GetWeight());
+
+        // mutex owned by another thread (slow path/blocking)
+        if (svc->Wait(this, &cs_, timeout_ticks)->IsTimeout())
+        {
+            // if owner did not change, undo priority boost to avoid stuck elevated priority: lookup for a
+            // higher weight within existing wait objects, noop if ISwitchStrategy::PRIORITY_INHERITANCE_API = 0
+            if (owner_tid == m_owner_tid)
+            {
+                svc->RestoreWeight(owner_tid, this);
+            }
+
+            success = false;
+        }
+        else
+        {
+            // kernel invariant: if either condition is false, the low-level lock and the
+            // recursion counter are out of sync, this is an internal defect, not a caller error
+            if ((m_owner_tid != current_tid) || (m_recursion_count != 1U))
+            {
+                STK_KERNEL_PANIC(KERNEL_PANIC_ASSERT);
+            }
+
+            success = true;
+        }
+    }
+    // try-lock variant: owned by someone else, but no-wait requested
+    else
+    {
+        // success is false already, noop
     }
 
-    // kernel invariant: if either condition is false, the low-level lock and the
-    // recursion counter are out of sync, this is an internal defect, not a caller error
-    if ((m_owner_tid != current_tid) || (m_recursion_count != 1U))
-        STK_KERNEL_PANIC(KERNEL_PANIC_ASSERT);
-
-    return true;
-}
+    return success;
+}    
 
 // ---------------------------------------------------------------------------
 // Unlock
@@ -178,7 +192,7 @@ inline bool Mutex::TimedLock(Timeout timeout)
 
 inline void Mutex::Unlock()
 {
-    ScopedCriticalSection cs_;
+    const ScopedCriticalSection cs_;
 
     STK_ASSERT(m_owner_tid == GetTid()); // API contract: caller must own the lock
     STK_ASSERT(m_recursion_count != 0U); // API contract: must have matching Lock()
@@ -187,7 +201,7 @@ inline void Mutex::Unlock()
 
     if (m_recursion_count == 0U)
     {
-        IKernelService *svc = IKernelService::GetInstance();
+        IKernelService *const svc = IKernelService::GetInstance();
 
         // restore priority of the owner, noop if ISwitchStrategy::PRIORITY_INHERITANCE_API = 0
         svc->RestoreWeight(m_owner_tid);
@@ -195,7 +209,7 @@ inline void Mutex::Unlock()
         if (!m_wait_list.IsEmpty())
         {
             // pass ownership directly to the first waiter (FIFO order)
-            IWaitObject *waiter = static_cast<IWaitObject *>(m_wait_list.GetFirst());
+            IWaitObject *const waiter = static_cast<IWaitObject *>(m_wait_list.GetFirst());
 
             // transfer ownership to the waiter
             m_recursion_count = 1U;

--- a/stk/include/sync/stk_sync_pipe.h
+++ b/stk/include/sync/stk_sync_pipe.h
@@ -10,8 +10,7 @@
 #ifndef STK_SYNC_PIPE_H_
 #define STK_SYNC_PIPE_H_
 
-#include <type_traits>
-#include <cstring> // for memcpy
+#include <type_traits> // for std::is_scalar
 
 #include "stk_sync_cv.h"
 
@@ -89,19 +88,19 @@ public:
                    ConditionVariable destructors.
         \note      MISRA deviation: [STK-DEV-005] Rule 10-3-2.
     */
-    ~Pipe() = default;
+    STK_VIRT_DTOR ~Pipe() = default;
 
     /*! \brief     Write a single element to the pipe.
         \details   Copies \a element_size bytes from \a data into the next available
                    slot in the ring buffer. If the pipe is full, the calling task is
                    suspended until space becomes available or the timeout expires.
         \param[in] data: Pointer to the element payload (must be at least \a element_size bytes).
-        \param[in] timeout: Maximum time to wait for space (ticks). Default: \c WAIT_INFINITE.
-        \warning   ISR-safe only with timeout=NO_WAIT, ISR-unsafe otherwise.
+        \param[in] timeout_ticks: Maximum time to wait for space (ticks). Default: \c WAIT_INFINITE.
+        \warning   ISR-safe only with timeout_ticks=NO_WAIT, ISR-unsafe otherwise.
         \return    \c true if data was successfully written, \c false if timeout expired
                    before space became available.
     */
-    bool Write(const void *data, Timeout timeout = WAIT_INFINITE);
+    bool Write(const void *data, Timeout timeout_ticks = WAIT_INFINITE);
 
     /*! \brief     Attempt to write a single element to the pipe without blocking.
         \details   Enqueues the element only if a free slot is immediately available.
@@ -119,8 +118,8 @@ public:
         \param[in] src: Pointer to the source array (must hold at least \a count elements
                    of \a element_size bytes each).
         \param[in] count: Number of elements to write.
-        \param[in] timeout: Maximum time to wait for sufficient space (ticks). Default: \c WAIT_INFINITE.
-        \warning   ISR-safe only with timeout=NO_WAIT, ISR-unsafe otherwise.
+        \param[in] timeout_ticks: Maximum time to wait for sufficient space (ticks). Default: \c WAIT_INFINITE.
+        \warning   ISR-safe only with timeout_ticks=NO_WAIT, ISR-unsafe otherwise.
         \return    Number of elements actually written. Equal to \c count unless a timeout occurred.
         \code
         // Example:
@@ -133,7 +132,7 @@ public:
         }
         \endcode
     */
-    size_t WriteBulk(const void *src, size_t count, Timeout timeout = WAIT_INFINITE);
+    size_t WriteBulk(const void *src, size_t count, Timeout timeout_ticks = WAIT_INFINITE);
 
     /*! \brief     Attempt to write multiple elements to the pipe without blocking.
         \details   Copies as many elements as possible without blocking. Elements that do not
@@ -150,12 +149,12 @@ public:
                    the buffer pointed to by \a data. If the pipe is empty, the calling task is
                    suspended until data is produced or the timeout expires.
         \param[out] data: Destination buffer for the retrieved element (must be at least \a element_size bytes).
-        \param[in] timeout: Maximum time to wait for data (ticks). Default: \c WAIT_INFINITE.
-        \warning   ISR-safe only with timeout=NO_WAIT, ISR-unsafe otherwise.
+        \param[in] timeout_ticks: Maximum time to wait for data (ticks). Default: \c WAIT_INFINITE.
+        \warning   ISR-safe only with timeout_ticks=NO_WAIT, ISR-unsafe otherwise.
         \return    \c true if data was successfully read, \c false if timeout expired before
                    any data became available.
     */
-    bool Read(void *data, Timeout timeout = WAIT_INFINITE);
+    bool Read(void *data, Timeout timeout_ticks = WAIT_INFINITE);
 
     /*! \brief     Attempt to read a single element from the pipe without blocking.
         \details   Dequeues an element only if one is immediately available.
@@ -173,8 +172,8 @@ public:
         \param[out] dst: Pointer to the destination array (must hold at least \a count elements
                    of \a element_size bytes each).
         \param[in] count:   Number of elements to read.
-        \param[in] timeout: Maximum time to wait for data (ticks). Default: \c WAIT_INFINITE.
-        \warning   ISR-safe only with timeout=NO_WAIT, ISR-unsafe otherwise.
+        \param[in] timeout_ticks: Maximum time to wait for data (ticks). Default: \c WAIT_INFINITE.
+        \warning   ISR-safe only with timeout_ticks=NO_WAIT, ISR-unsafe otherwise.
         \return    Number of elements actually read. Equal to \c count unless a timeout occurred.
         \code
         // Example:
@@ -188,7 +187,7 @@ public:
         }
         \endcode
     */
-    size_t ReadBulk(void *dst, size_t count, Timeout timeout = WAIT_INFINITE);
+    size_t ReadBulk(void *dst, size_t count, Timeout timeout_ticks = WAIT_INFINITE);
 
     /*! \brief     Attempt to read multiple elements from the pipe without blocking.
         \details   Reads as many elements as are currently available without blocking.
@@ -210,8 +209,8 @@ public:
         \param[in] trigger: Minimum number of elements that must be available before any
                    data is dequeued. Clamped to [1, max_count] internally.
         \param[in] max_count: Maximum number of elements to return in total.
-        \param[in] timeout: Maximum time to wait for \a trigger elements. Default: \c WAIT_INFINITE.
-        \warning   ISR-safe only with timeout=NO_WAIT, ISR-unsafe otherwise.
+        \param[in] timeout_ticks: Maximum time to wait for \a trigger elements. Default: \c WAIT_INFINITE.
+        \warning   ISR-safe only with timeout_ticks=NO_WAIT, ISR-unsafe otherwise.
         \return    Number of elements actually read.
                    - Equal to zero if timeout fired before a single element arrived.
                    - Greater than zero but less than \a trigger if a partial trigger's worth of
@@ -220,8 +219,8 @@ public:
                    - Greater than or equal to \a trigger if the threshold was satisfied (the
                      caller may then assume the trigger callback condition is met).
     */
-    size_t ReadBulkTriggered(void *dst, size_t trigger, size_t max_count,
-                             Timeout timeout = WAIT_INFINITE);
+    size_t ReadBulkTriggered(void *dst, size_t trigger, size_t max_count, 
+                             Timeout timeout_ticks = WAIT_INFINITE);
 
     /*! \brief     Non-blocking variant of ReadBulkTriggered.
         \details   Returns immediately with however many elements are available, up to
@@ -346,71 +345,103 @@ inline Pipe::Pipe(uint8_t *buf, size_t capacity, size_t element_size)
 // Pipe: Write
 // ---------------------------------------------------------------------------
 
-inline bool Pipe::Write(const void *data, Timeout timeout)
+inline bool Pipe::Write(const void *data, Timeout timeout_ticks)
 {
     STK_ASSERT(data    != nullptr);
     STK_ASSERT(m_count <= (CAPACITY_MAX - 1U));
 
     ScopedCriticalSection cs_;
+    bool success = true;
 
     while (m_count == m_capacity)
     {
-        if (!m_cv_not_full.Wait(cs_, timeout))
-            return false;
+        if (!m_cv_not_full.Wait(cs_, timeout_ticks))
+        {
+            success = false;
+            break;
+        }
     }
 
-    memcpy(Slot(m_head), data, m_element_size);
-    m_head = Next(m_head);
-    m_count++;
+    if (success)
+    {
+        STK_MEMCPY(Slot(m_head), data, m_element_size);
+        m_head = Next(m_head);
+        m_count++;
 
-    // notify consumer that data is ready
-    m_cv_not_empty.NotifyOne_CS();
+        // notify consumer that data is ready
+        m_cv_not_empty.NotifyOne_CS();
+    }
 
-    return true;
+    return success;
 }
 
 // ---------------------------------------------------------------------------
 // Pipe: WriteBulk
 // ---------------------------------------------------------------------------
 
-inline size_t Pipe::WriteBulk(const void *src, size_t count, Timeout timeout)
+inline size_t Pipe::WriteBulk(const void *src, size_t count, Timeout timeout_ticks)
 {
-    if ((src == nullptr) || (count == 0U))
-        return 0U;
-
     size_t written = 0U;
-    const uint8_t *src_bytes = static_cast<const uint8_t *>(src);
 
-    ScopedCriticalSection cs_;
-
-    while (written < count)
+    if ((src != nullptr) && (count != 0U))
     {
-        while (m_count == m_capacity)
+        const uint8_t *const src_bytes = static_cast<const uint8_t *>(src);
+        const bool timed_wait = (timeout_ticks != WAIT_INFINITE) && (timeout_ticks != NO_WAIT);
+        
+        // capture an absolute deadline once, before entering the wait loop,
+        // preventing the timeout from resetting on intermediate partial writes
+        const Timeout deadline = (timed_wait ? 
+            static_cast<Timeout>(GetTicks() + timeout_ticks) : timeout_ticks);
+
+        ScopedCriticalSection cs_;
+
+        while (written < count)
         {
-            if (!m_cv_not_full.Wait(cs_, timeout))
-                return written; // return partial count on timeout
+            bool is_timeout = false;
+
+            while (m_count == m_capacity)
+            {
+                Timeout remaining = deadline;
+                if (timed_wait)
+                {
+                    const Timeout now = static_cast<Timeout>(GetTicks());
+                    remaining = (now >= deadline ? NO_WAIT : (deadline - now));
+                }
+
+                if (!m_cv_not_full.Wait(cs_, remaining))
+                {
+                    is_timeout = true;
+                    break; // break inner condition variable loop
+                }
+            }
+
+            // if a timeout occurred, drop out of the chunk processing loop
+            if (is_timeout)
+            {
+                break;
+            }
+
+            const size_t available  = m_capacity - m_count;
+            const size_t to_write   = ((count - written) < available) ? (count - written) : available;
+            const size_t first_part = m_capacity - m_head;
+
+            if (to_write <= first_part)
+            {
+                STK_MEMCPY(Slot(m_head), src_bytes + (written * m_element_size), to_write * m_element_size);
+            }
+            else
+            {
+                STK_MEMCPY(Slot(m_head), src_bytes + (written                * m_element_size), first_part              * m_element_size);
+                STK_MEMCPY(Slot(0U),     src_bytes + ((written + first_part) * m_element_size), (to_write - first_part) * m_element_size);
+            }
+
+            written += to_write;
+            m_head   = (m_head + to_write) % m_capacity;
+            m_count += to_write;
+
+            // notify consumers that data is ready
+            m_cv_not_empty.NotifyAll_CS();
         }
-
-        size_t available  = m_capacity - m_count;
-        size_t to_write   = (count - written) < available ? (count - written) : available;
-        size_t first_part = m_capacity - m_head;
-
-        if (to_write <= first_part)
-        {
-            memcpy(Slot(m_head), src_bytes + (written * m_element_size), to_write * m_element_size);
-        }
-        else
-        {
-            memcpy(Slot(m_head), src_bytes + (written                * m_element_size), first_part              * m_element_size);
-            memcpy(Slot(0U),     src_bytes + ((written + first_part) * m_element_size), (to_write - first_part) * m_element_size);
-        }
-
-        written += to_write;
-        m_head   = (m_head + to_write) % m_capacity;
-        m_count += to_write;
-
-        // notify consumers that data is ready
-        m_cv_not_empty.NotifyAll_CS();
     }
 
     return written;
@@ -420,45 +451,52 @@ inline size_t Pipe::WriteBulk(const void *src, size_t count, Timeout timeout)
 // Pipe: Read
 // ---------------------------------------------------------------------------
 
-inline bool Pipe::Read(void *data, Timeout timeout)
+inline bool Pipe::Read(void *data, Timeout timeout_ticks)
 {
     STK_ASSERT(data != nullptr);
 
     ScopedCriticalSection cs_;
+    bool success = true;
 
     while (m_count == 0U)
     {
-        if (!m_cv_not_empty.Wait(cs_, timeout))
-            return false;
+        if (!m_cv_not_empty.Wait(cs_, timeout_ticks))
+        {
+            success = false;
+            break;
+        }
     }
 
-    memcpy(data, Slot(m_tail), m_element_size);
-    m_tail = Next(m_tail);
-    m_count--;
+    if (success)
+    {
+        STK_MEMCPY(data, Slot(m_tail), m_element_size);
+        m_tail = Next(m_tail);
+        m_count--;
 
-    // notify producer that space is now available
-    m_cv_not_full.NotifyOne_CS();
+        // notify producer that space is now available
+        m_cv_not_full.NotifyOne_CS();
+    }
 
-    return true;
+    return success;
 }
 
 // ---------------------------------------------------------------------------
-// Pipe: DrainLocked  (private helper — caller must hold the critical section)
+// Pipe: DrainLocked  (private helper, caller must hold the critical section)
 // ---------------------------------------------------------------------------
 
-inline size_t Pipe::DrainLocked(uint8_t *dst_bytes, size_t count)
+inline size_t Pipe::DrainLocked(uint8_t *const dst_bytes, const size_t count)
 {
     const size_t to_read    = Min(count, m_count);
     const size_t first_part = m_capacity - m_tail;
 
     if (to_read <= first_part)
     {
-        memcpy(dst_bytes, Slot(m_tail), to_read * m_element_size);
+        STK_MEMCPY(dst_bytes, Slot(m_tail), to_read * m_element_size);
     }
     else
     {
-        memcpy(dst_bytes,                               Slot(m_tail), first_part             * m_element_size);
-        memcpy(dst_bytes + first_part * m_element_size, Slot(0U),     (to_read - first_part) * m_element_size);
+        STK_MEMCPY(dst_bytes,                                 Slot(m_tail), first_part             * m_element_size);
+        STK_MEMCPY(dst_bytes + (first_part * m_element_size), Slot(0U),     (to_read - first_part) * m_element_size);
     }
 
     m_tail   = (m_tail + to_read) % m_capacity;
@@ -472,25 +510,51 @@ inline size_t Pipe::DrainLocked(uint8_t *dst_bytes, size_t count)
 // Pipe: ReadBulk
 // ---------------------------------------------------------------------------
 
-inline size_t Pipe::ReadBulk(void *dst, size_t count, Timeout timeout)
+inline size_t Pipe::ReadBulk(void *dst, size_t count, Timeout timeout_ticks)
 {
-    if ((dst == nullptr) || (count == 0U))
-        return 0U;
+    size_t read_count = 0U;
 
-    size_t   read_count = 0U;
-    uint8_t *dst_bytes  = static_cast<uint8_t *>(dst);
-
-    ScopedCriticalSection cs_;
-
-    while (read_count < count)
+    if ((dst != nullptr) && (count != 0U))
     {
-        while (m_count == 0U)
-        {
-            if (!m_cv_not_empty.Wait(cs_, timeout))
-                return read_count;
-        }
+        uint8_t *const dst_bytes = static_cast<uint8_t *>(dst);
+        const bool timed_wait = (timeout_ticks != WAIT_INFINITE) && (timeout_ticks != NO_WAIT);
+        
+        // capture an absolute deadline once, before entering the wait loop,
+        // preventing the timeout from resetting on intermediate partial reads
+        const Timeout deadline = (timed_wait ? 
+            static_cast<Timeout>(GetTicks() + timeout_ticks) : timeout_ticks);
 
-        read_count += DrainLocked(dst_bytes + (read_count * m_element_size), count - read_count);
+        ScopedCriticalSection cs_;
+
+        while (read_count < count)
+        {
+            bool is_timeout = false;
+
+            while (m_count == 0U)
+            {
+                Timeout remaining = deadline;
+                if (timed_wait)
+                {
+                    const Timeout now = static_cast<Timeout>(GetTicks());
+                    remaining = (now >= deadline ? NO_WAIT : (deadline - now));
+                }
+
+                if (!m_cv_not_empty.Wait(cs_, remaining))
+                {
+                    is_timeout = true;
+                    break; // break inner condition variable loop
+                }
+            }
+
+            // if a timeout occurred, drop out of the chunk processing loop
+            if (is_timeout)
+            {
+                break;
+            }
+
+            // drain data using the state tracker's relative byte offsets
+            read_count += DrainLocked(dst_bytes + (read_count * m_element_size), count - read_count);
+        }
     }
 
     return read_count;
@@ -500,27 +564,47 @@ inline size_t Pipe::ReadBulk(void *dst, size_t count, Timeout timeout)
 // Pipe: ReadBulkTriggered
 // ---------------------------------------------------------------------------
 
-inline size_t Pipe::ReadBulkTriggered(void *dst, size_t trigger, size_t max_count, Timeout timeout)
+inline size_t Pipe::ReadBulkTriggered(void *dst, size_t trigger, size_t max_count, Timeout timeout_ticks)
 {
-    if ((dst == nullptr) || (max_count == 0U))
-        return 0U;
+    size_t read_count = 0U;
 
-    // trigger must be in [1, max_count]
-    if (trigger == 0U)       trigger = 1U;
-    if (trigger > max_count) trigger = max_count;
-
-    uint8_t *dst_bytes = static_cast<uint8_t *>(dst);
-
-    ScopedCriticalSection cs_;
-
-    while (m_count < trigger)
+    if ((dst != nullptr) && (max_count != 0U))
     {
-        if (!m_cv_not_empty.Wait(cs_, timeout))
-            return DrainLocked(dst_bytes, max_count); // timeout: drain whatever arrived
+        // trigger must be in [1, max_count]
+        if (trigger == 0U)       { trigger = 1U; }
+        if (trigger > max_count) { trigger = max_count; }
+
+        uint8_t *const dst_bytes = static_cast<uint8_t *>(dst);
+        const bool timed_wait = (timeout_ticks != WAIT_INFINITE) && (timeout_ticks != NO_WAIT);
+        
+        // capture an absolute deadline once, before entering the wait loop,
+        // preventing the timeout from resetting on intermediate spurious wakeups
+        const Timeout deadline = (timed_wait ? 
+            static_cast<Timeout>(GetTicks() + timeout_ticks) : timeout_ticks);
+
+        ScopedCriticalSection cs_;
+
+        while (m_count < trigger)
+        {
+            Timeout remaining = deadline;
+            if (timed_wait)
+            {
+                const Timeout now = static_cast<Timeout>(GetTicks());
+                remaining = (now >= deadline ? NO_WAIT : (deadline - now));
+            }
+
+            if (!m_cv_not_empty.Wait(cs_, remaining))
+            {
+                break; // break the waiting loop on timeout
+            }
+        }
+
+        // whether we broke out via satisfying the trigger or hitting a timeout,
+        // we drain whatever is currently available up to max_count
+        read_count = DrainLocked(dst_bytes, max_count);
     }
 
-    // trigger satisfied, drain up to max_count without further blocking
-    return DrainLocked(dst_bytes, max_count);
+    return read_count;
 }
 
 // ---------------------------------------------------------------------------
@@ -529,7 +613,7 @@ inline size_t Pipe::ReadBulkTriggered(void *dst, size_t trigger, size_t max_coun
 
 inline void Pipe::Reset()
 {
-    ScopedCriticalSection cs_;
+    const ScopedCriticalSection cs_;
 
     m_count = 0U;
     m_head  = 0U;
@@ -597,29 +681,36 @@ public:
                    calling task will be suspended until space is made available by a
                    consumer or the timeout expires.
         \param[in] data: Reference to the data element to be copied into the pipe.
-        \param[in] timeout: Maximum time to wait for space (ticks). Default: \c WAIT_INFINITE.
-        \warning   ISR-safe only with timeout=NO_WAIT, ISR-unsafe otherwise.
+        \param[in] timeout_ticks: Maximum time to wait for space (ticks). Default: \c WAIT_INFINITE.
+        \warning   ISR-safe only with timeout_ticks=NO_WAIT, ISR-unsafe otherwise.
         \return    \c true if data was successfully written, \c false if timeout expired
                    before space became available.
     */
-    bool Write(const T &data, Timeout timeout = WAIT_INFINITE)
+    bool Write(const T &data, Timeout timeout_ticks = WAIT_INFINITE)
     {
         ScopedCriticalSection cs_;
+        bool success = true;
 
         while (m_count == N)
         {
-            if (!m_cv_not_full.Wait(cs_, timeout))
-                return false;
+            if (!m_cv_not_full.Wait(cs_, timeout_ticks))
+            {
+                success = false;
+                break;
+            }
         }
 
-        m_buffer[m_head] = data;
-        m_head = (m_head + 1U) % N;
-        m_count += 1U;
+        if (success)
+        {
+            m_buffer[m_head] = data;
+            m_head = (m_head + 1U) % N;
+            m_count += 1U;
 
-        // notify consumer that data is ready
-        m_cv_not_empty.NotifyOne_CS();
+            // notify consumer that data is ready
+            m_cv_not_empty.NotifyOne_CS();
+        }
 
-        return true;
+        return success;
     }
 
     /*! \brief     Attempt to write data to the pipe without blocking.
@@ -637,8 +728,8 @@ public:
                    amount can be written or the timeout expires.
         \param[in] src: Pointer to the source array.
         \param[in] count: Number of elements to write.
-        \param[in] timeout: Maximum time to wait for sufficient space (ticks). Default: \c WAIT_INFINITE.
-        \warning   ISR-safe only with timeout=NO_WAIT, ISR-unsafe otherwise.
+        \param[in] timeout_ticks: Maximum time to wait for sufficient space (ticks). Default: \c WAIT_INFINITE.
+        \warning   ISR-safe only with timeout_ticks=NO_WAIT, ISR-unsafe otherwise.
         \return    Number of elements actually written. Equal to \c count unless a timeout occurred.
         \code
         // Example:
@@ -651,57 +742,85 @@ public:
         }
         \endcode
     */
-    size_t WriteBulk(const T *src, size_t count, Timeout timeout = WAIT_INFINITE)
+    size_t WriteBulk(const T *src, size_t count, Timeout timeout_ticks = WAIT_INFINITE)
     {
-        if ((src == nullptr) || (count == 0U))
-            return 0U;
-
         size_t written = 0U;
-        ScopedCriticalSection cs_;
 
-        while (written < count)
+        if ((src != nullptr) && (count != 0U))
         {
-            while (m_count == N)
-            {
-                if (!m_cv_not_full.Wait(cs_, timeout))
-                    return written; // return partial count on timeout
-            }
+            const bool timed_wait = (timeout_ticks != WAIT_INFINITE) && (timeout_ticks != NO_WAIT);
+            
+            // capture an absolute deadline once, before entering the wait loop,
+            // preventing the timeout from resetting on intermediate partial writes
+            const Timeout deadline = (timed_wait ? 
+                static_cast<Timeout>(GetTicks() + timeout_ticks) : timeout_ticks);
 
-            // calculate how many we can copy in this contiguous stretch
-            size_t available = N - m_count;
-            size_t to_write  = ((count - written) < available) ? (count - written) : available;
+            ScopedCriticalSection cs_;
 
-            // copy from source
-            // note: if value type is not scalar or queue is small we copy with a for loop,
-            //       otherwise using faster memcpy version for large scalar arrays
-            if (!std::is_scalar<T>::value || (N < 8U))
+            while (written < count)
             {
-                for (size_t i = 0U; i < to_write; ++i)
+                bool is_timeout = false;
+
+                while (m_count == N)
                 {
-                    m_buffer[m_head] = src[written++];
-                    m_head = (m_head + 1U) % N;
-                    m_count += 1U;
+                    Timeout remaining = deadline;
+                    if (timed_wait)
+                    {
+                        const Timeout now = static_cast<Timeout>(GetTicks());
+                        remaining = (now >= deadline ? NO_WAIT : (deadline - now));
+                    }
+
+                    if (!m_cv_not_full.Wait(cs_, remaining))
+                    {
+                        is_timeout = true; 
+                        break; // break inner condition variable loop
+                    }
                 }
-            }
-            else
-            {
-                size_t first_part = N - m_head;
-                if (to_write <= first_part)
+
+                // if timeout, drop out of the chunk processing loop
+                if (is_timeout)
                 {
-                    memcpy(&m_buffer[m_head], &src[written], to_write * sizeof(T));
+                    break; 
+                }
+
+                // calculate how many we can copy in this contiguous stretch
+                const size_t available = N - m_count;
+                const size_t to_write  = ((count - written) < available) ? (count - written) : available;
+
+                // copy from source
+                // note: if value type is not scalar or queue is small we copy with a for loop,
+                //       otherwise using faster memcpy version for large scalar arrays
+                if (!std::is_scalar<T>::value || (N < 8U))
+                {
+                    for (size_t i = 0U; i < to_write; ++i)
+                    {
+                        m_buffer[m_head] = src[written++];
+                        m_head           = (m_head + 1U) % N;
+                        m_count         += 1U;
+                    }
                 }
                 else
                 {
-                    memcpy(&m_buffer[m_head], &src[written],              first_part              * sizeof(T));
-                    memcpy(&m_buffer[0U],     &src[written + first_part], (to_write - first_part) * sizeof(T));
+                    const size_t first_part = N - m_head;
+                    
+                    if (to_write <= first_part)
+                    {
+                        STK_MEMCPY(&m_buffer[m_head], &src[written], to_write * sizeof(T));
+                    }
+                    else
+                    {
+                        STK_MEMCPY(&m_buffer[m_head], &src[written],              first_part              * sizeof(T));
+                        STK_MEMCPY(&m_buffer[0U],     &src[written + first_part], (to_write - first_part) * sizeof(T));
+                    }
+                    
+                    written += to_write;
+                    m_head   = (m_head + to_write) % N;
+                    m_count += to_write;
                 }
-                written += to_write;
-                m_head   = (m_head + to_write) % N;
-                m_count += to_write;
-            }
 
-            // notify consumers that data is ready
-            m_cv_not_empty.NotifyAll_CS();
+                // notify consumers that data is ready
+                m_cv_not_empty.NotifyAll_CS();
+            }
         }
 
         return written;
@@ -722,31 +841,38 @@ public:
                    the calling task will be suspended until data is provided by a
                    producer or the timeout expires.
         \param[out] data: Reference to the variable where the retrieved data will be stored.
-        \param[in] timeout: Maximum time to wait for data (ticks). Default: \c WAIT_INFINITE.
-        \warning   ISR-safe only with timeout=NO_WAIT, ISR-unsafe otherwise.
+        \param[in] timeout_ticks: Maximum time to wait for data (ticks). Default: \c WAIT_INFINITE.
+        \warning   ISR-safe only with timeout_ticks=NO_WAIT, ISR-unsafe otherwise.
         \return    \c true if data was successfully read, \c false if timeout expired before
                    any data became available.
     */
-    bool Read(T &data, Timeout timeout = WAIT_INFINITE)
+    bool Read(T &data, Timeout timeout_ticks = WAIT_INFINITE)
     {
         ScopedCriticalSection cs_;
+        bool success = true;
 
         while (m_count == 0U)
         {
-            if (!m_cv_not_empty.Wait(cs_, timeout))
-                return false;
+            if (!m_cv_not_empty.Wait(cs_, timeout_ticks))
+            {
+                success = false;
+                break;
+            }
         }
 
-        data    = m_buffer[m_tail];
-        m_tail  = (m_tail + 1U) % N;
-        m_count -= 1U;
+        if (success)
+        {
+            data     = m_buffer[m_tail];
+            m_tail   = (m_tail + 1U) % N;
+            m_count -= 1U;
 
-        // notify producer that space is available
-        m_cv_not_full.NotifyOne_CS();
+            // notify producer that space is available
+            m_cv_not_full.NotifyOne_CS();
+        }
 
-        return true;
+        return success;
     }
-
+    
     /*! \brief     Attempt to read data from the pipe without blocking.
         \details   Dequeues an element only if one is immediately available.
                    Returns \c false instantly if the pipe is empty.
@@ -762,8 +888,8 @@ public:
                    until the full amount is read or the timeout expires.
         \param[out] dst: Pointer to the destination array.
         \param[in] count: Number of elements to read.
-        \param[in] timeout: Maximum time to wait for data (ticks). Default: \c WAIT_INFINITE.
-        \warning   ISR-safe only with timeout=NO_WAIT, ISR-unsafe otherwise.
+        \param[in] timeout_ticks: Maximum time to wait for data (ticks). Default: \c WAIT_INFINITE.
+        \warning   ISR-safe only with timeout_ticks=NO_WAIT, ISR-unsafe otherwise.
         \return    Number of elements actually read. Equal to \c count unless a timeout occurred.
         \code
         // Example:
@@ -777,56 +903,85 @@ public:
         }
         \endcode
     */
-    size_t ReadBulk(T *dst, size_t count, Timeout timeout = WAIT_INFINITE)
+    size_t ReadBulk(T *dst, size_t count, Timeout timeout_ticks = WAIT_INFINITE)
     {
-        if ((dst == nullptr) || (count == 0U))
-            return 0U;
-
         size_t read_count = 0U;
-        ScopedCriticalSection cs_;
 
-        while (read_count < count)
+        if ((dst != nullptr) && (count != 0U))
         {
-            // wait until there is at least 1 element available
-            while (m_count == 0U)
-            {
-                if (!m_cv_not_empty.Wait(cs_, timeout))
-                    return read_count; // return partial count on timeout
-            }
+            const bool timed_wait = (timeout_ticks != WAIT_INFINITE) && (timeout_ticks != NO_WAIT);
+            
+            // capture an absolute deadline once, before entering the wait loop,
+            // this prevents the timeout from being silently restarted on each
+            // spurious wakeup (e.g. a partial Set() that does not satisfy WAIT_ALL)
+            const Timeout deadline = (timed_wait ? 
+                static_cast<Timeout>(GetTicks() + timeout_ticks) : timeout_ticks);
 
-            // determine how many we can pull in this stretch
-            size_t to_read = (count - read_count) < m_count ? (count - read_count) : m_count;
+            ScopedCriticalSection cs_;
 
-            // note: if value type is not scalar or queue is small we copy with a for loop,
-            //       otherwise using faster memcpy version for large scalar arrays
-            if (!std::is_scalar<T>::value || (N < 8U))
+            while (read_count < count)
             {
-                for (size_t i = 0U; i < to_read; ++i)
+                bool is_timeout = false;
+              
+                // wait until there is at least 1 element available
+                while (m_count == 0U)
                 {
-                    dst[read_count++] = m_buffer[m_tail];
-                    m_tail  = (m_tail + 1U) % N;
-                    m_count -= 1U;
+                    Timeout remaining = deadline;
+                    if (timed_wait)
+                    {
+                        const Timeout now = static_cast<Timeout>(GetTicks());
+                        remaining = (now >= deadline ? NO_WAIT : (deadline - now));
+                    }
+
+                    if (!m_cv_not_empty.Wait(cs_, remaining))
+                    {
+                        is_timeout = true;
+                        break; // break inner condition variable loop
+                    }
                 }
-            }
-            else
-            {
-                size_t first_part = N - m_tail;
-                if (to_read <= first_part)
+
+                // if a timeout, drop out of the chunk processing loop
+                if (is_timeout)
                 {
-                    memcpy(&dst[read_count], &m_buffer[m_tail], to_read * sizeof(T));
+                    break;
+                }
+
+                // determine how many we can pull in this stretch
+                const size_t to_read = (count - read_count) < m_count ? (count - read_count) : m_count;
+
+                // note: if value type is not scalar or queue is small we copy with a for loop,
+                //       otherwise using faster memcpy version for large scalar arrays
+                if (!std::is_scalar<T>::value || (N < 8U))
+                {
+                    for (size_t i = 0U; i < to_read; ++i)
+                    {
+                        dst[read_count++] = m_buffer[m_tail];
+                        m_tail            = (m_tail + 1U) % N;
+                        m_count          -= 1U;
+                    }
                 }
                 else
                 {
-                    memcpy(&dst[read_count],              &m_buffer[m_tail], first_part              * sizeof(T));
-                    memcpy(&dst[read_count + first_part], &m_buffer[0U],     (to_read - first_part)  * sizeof(T));
+                    const size_t first_part = N - m_tail;
+                    
+                    if (to_read <= first_part)
+                    {
+                        STK_MEMCPY(&dst[read_count], &m_buffer[m_tail], to_read * sizeof(T));
+                    }
+                    else
+                    {
+                        STK_MEMCPY(&dst[read_count],              &m_buffer[m_tail], first_part              * sizeof(T));
+                        STK_MEMCPY(&dst[read_count + first_part], &m_buffer[0U],     (to_read - first_part)  * sizeof(T));
+                    }
+                    
+                    read_count += to_read;
+                    m_tail      = (m_tail + to_read) % N;
+                    m_count    -= to_read;
                 }
-                read_count += to_read;
-                m_tail      = (m_tail + to_read) % N;
-                m_count    -= to_read;
-            }
 
-            // notify producers that space is now available
-            m_cv_not_full.NotifyAll_CS();
+                // notify producers that space is now available
+                m_cv_not_full.NotifyAll_CS();
+            }
         }
 
         return read_count;
@@ -850,7 +1005,7 @@ public:
     */
     void Reset()
     {
-        ScopedCriticalSection cs_;
+        const ScopedCriticalSection cs_;
 
         m_count = 0U;
         m_head  = 0U;

--- a/stk/include/sync/stk_sync_rwmutex.h
+++ b/stk/include/sync/stk_sync_rwmutex.h
@@ -72,7 +72,7 @@ public:
                 An assertion is triggered in debug builds.
         \note   MISRA deviation: [STK-DEV-005] Rule 10-3-2.
     */
-    ~RWMutex()
+    STK_VIRT_DTOR ~RWMutex()
     {
         // API contract: must not be destroyed while readers are active, writers are waiting,
         // or a writer holds the lock
@@ -87,10 +87,10 @@ public:
     public:
         /*! \brief     Constructs the guard and attempts to acquire the write lock.
             \param[in] rw: Reference to the RWMutex.
-            \param[in] timeout: Maximum time to wait (ticks). Use NO_WAIT for non-blocking (TryLock).
+            \param[in] timeout_ticks: Maximum time to wait (ticks). Use NO_WAIT for non-blocking (TryLock).
         */
-        explicit ScopedTimedLock(RWMutex &rw, Timeout timeout = WAIT_INFINITE)
-            : m_rw(rw), m_locked(rw.TimedLock(timeout))
+        explicit ScopedTimedLock(RWMutex &rw, Timeout timeout_ticks = WAIT_INFINITE)
+            : m_rw(rw), m_locked(rw.TimedLock(timeout_ticks))
         {}
 
         ~ScopedTimedLock() { if (m_locked) { m_rw.Unlock(); } }
@@ -112,10 +112,10 @@ public:
     public:
         /*! \brief     Constructs the guard and attempts to acquire the read lock.
             \param[in] rw: Reference to the RWMutex.
-            \param[in] timeout: Maximum time to wait (ticks). Use NO_WAIT for non-blocking (TryReadLock).
+            \param[in] timeout_ticks: Maximum time to wait (ticks). Use NO_WAIT for non-blocking (TryReadLock).
         */
-        explicit ScopedTimedReadMutex(RWMutex &rw, Timeout timeout = WAIT_INFINITE)
-            : m_rw(rw), m_locked(rw.TimedReadLock(timeout))
+        explicit ScopedTimedReadMutex(RWMutex &rw, Timeout timeout_ticks = WAIT_INFINITE)
+            : m_rw(rw), m_locked(rw.TimedReadLock(timeout_ticks))
         {}
 
         ~ScopedTimedReadMutex() { if (m_locked) { m_rw.ReadUnlock(); } }
@@ -130,12 +130,12 @@ public:
     };
 
     /*! \brief     Acquire the lock for shared reading with a timeout.
-        \param[in] timeout: Maximum time to wait (ticks).
+        \param[in] timeout_ticks: Maximum time to wait (ticks).
         \note      Non-recursive.
         \return    True if lock acquired, false if timeout occurred.
-        \warning   ISR-safe only with \a timeout = \c NO_WAIT, ISR-unsafe otherwise.
+        \warning   ISR-safe only with \a timeout_ticks = \c NO_WAIT, ISR-unsafe otherwise.
     */
-    bool TimedReadLock(Timeout timeout);
+    bool TimedReadLock(Timeout timeout_ticks);
 
     /*! \brief     Acquire the lock for shared reading.
         \details   Blocks the calling task if a writer is currently active or if there
@@ -162,12 +162,12 @@ public:
     void ReadUnlock();
 
     /*! \brief     Acquire the lock for exclusive writing with a timeout.
-        \param[in] timeout: Maximum time to wait (ticks).
+        \param[in] timeout_ticks: Maximum time to wait (ticks).
         \return    True if lock acquired, false if timeout occurred.
         \note      Non-recursive.
-        \warning   ISR-safe only with \a timeout = \c NO_WAIT, ISR-unsafe otherwise.
+        \warning   ISR-safe only with \a timeout_ticks = \c NO_WAIT, ISR-unsafe otherwise.
     */
-    bool TimedLock(Timeout timeout);
+    bool TimedLock(Timeout timeout_ticks);
 
     /*! \brief     Acquire the lock for exclusive writing (IMutex interface).
         \details   Blocks the calling task until all active readers have released their
@@ -209,23 +209,32 @@ private:
 // TimedReadLock
 // ---------------------------------------------------------------------------
 
-inline bool RWMutex::TimedReadLock(Timeout timeout)
+inline bool RWMutex::TimedReadLock(Timeout timeout_ticks)
 {
+    bool success = true;
     ScopedCriticalSection cs_;
 
     // wait if there is an active writer or if writers are waiting (Writer Preference)
     while (m_writer_active || (m_writers_waiting != 0U))
     {
-        if (!m_cv_readers.Wait(cs_, timeout))
-            return false; // timeout
+        if (!m_cv_readers.Wait(cs_, timeout_ticks))
+        {
+            success = false; // timeout
+            break;
+        }
 
         // re-check on wake: another writer may have queued up while this task was sleeping
     }
 
-    STK_ASSERT(m_readers < READERS_MAX); // API contract: reader count must not exceed maximum
+    // only increment reader count if the lock was successfully acquired without timing out
+    if (success)
+    {
+        STK_ASSERT(m_readers < READERS_MAX); // API contract: reader count must not exceed maximum
 
-    m_readers = static_cast<uint16_t>(m_readers + 1U);
-    return true;
+        m_readers = static_cast<uint16_t>(m_readers + 1U);
+    }
+
+    return success;
 }
 
 // ---------------------------------------------------------------------------
@@ -234,7 +243,7 @@ inline bool RWMutex::TimedReadLock(Timeout timeout)
 
 inline void RWMutex::ReadUnlock()
 {
-    ScopedCriticalSection cs_;
+    const ScopedCriticalSection cs_;
 
     STK_ASSERT(m_readers != 0U); // API contract: must have a matching ReadLock()
 
@@ -242,15 +251,18 @@ inline void RWMutex::ReadUnlock()
 
     // wake a waiting writer when the last reader exits
     if (m_readers == 0U)
+    {
         m_cv_writers.NotifyOne_CS();
+    }
 }
 
 // ---------------------------------------------------------------------------
 // TimedLock
 // ---------------------------------------------------------------------------
 
-inline bool RWMutex::TimedLock(Timeout timeout)
+inline bool RWMutex::TimedLock(Timeout timeout_ticks)
 {
+    bool success = true;
     ScopedCriticalSection cs_;
 
     STK_ASSERT(m_writers_waiting < WRITERS_MAX); // API contract: waiting writer count must not exceed maximum
@@ -260,22 +272,30 @@ inline bool RWMutex::TimedLock(Timeout timeout)
     // wait until there are no active readers and no active writer
     while (m_writer_active || (m_readers != 0U))
     {
-        if (!m_cv_writers.Wait(cs_, timeout))
+        if (!m_cv_writers.Wait(cs_, timeout_ticks))
         {
             // timed out: withdraw from the waiting writers queue
             m_writers_waiting = static_cast<uint16_t>(m_writers_waiting - 1U);
-            return false;
+            success = false;
+            break;
         }
     }
 
-    m_writers_waiting = static_cast<uint16_t>(m_writers_waiting - 1U);
+    // only finalize state if the wait didn't time out
+    if (success)
+    {
+        m_writers_waiting = static_cast<uint16_t>(m_writers_waiting - 1U);
 
-    // kernel invariant: no readers and no active writer when lock is granted
-    if ((m_readers != 0U) || m_writer_active)
-        STK_KERNEL_PANIC(KERNEL_PANIC_ASSERT);
+        // kernel invariant: no readers and no active writer when lock is granted
+        if ((m_readers != 0U) || m_writer_active)
+        {
+            STK_KERNEL_PANIC(KERNEL_PANIC_ASSERT);
+        }
 
-    m_writer_active = true;
-    return true;
+        m_writer_active = true;
+    }
+
+    return success;
 }
 
 // ---------------------------------------------------------------------------
@@ -284,7 +304,7 @@ inline bool RWMutex::TimedLock(Timeout timeout)
 
 inline void RWMutex::Unlock()
 {
-    ScopedCriticalSection cs_;
+    const ScopedCriticalSection cs_;
 
     STK_ASSERT(m_writer_active); // API contract: caller must hold the write lock
 
@@ -293,9 +313,13 @@ inline void RWMutex::Unlock()
     // prioritize waking waiting writers to prevent writer starvation;
     // only wake readers if no writers are queued
     if (m_writers_waiting != 0U)
+    {
         m_cv_writers.NotifyOne_CS();
+    }
     else
+    {
         m_cv_readers.NotifyAll_CS();
+    }
 }
 
 } // namespace sync

--- a/stk/include/sync/stk_sync_semaphore.h
+++ b/stk/include/sync/stk_sync_semaphore.h
@@ -52,12 +52,12 @@ namespace sync {
     \see  ISyncObject, IWaitObject, IKernelService::Wait
     \note Only available when kernel is compiled with \a KERNEL_SYNC mode enabled.
 */
-class Semaphore final : public ITraceable, private ISyncObject
+class Semaphore final : private ISyncObject, public ITraceable
 {
 public:
-    /*! \brief     Max count supported.
+    /*! \brief     Max count value supported.
     */
-    static const size_t COUNT_MAX = 0xFFFEU;
+    static const uint16_t COUNT_MAX = 0xFFFEU;
 
     /*! \brief     Constructor.
         \details   Initializes the semaphore with a specific count and maximum limit.
@@ -80,17 +80,17 @@ public:
                    An assertion is triggered in debug builds.
         \note      MISRA deviation: [STK-DEV-005] Rule 10-3-2.
     */
-    ~Semaphore()
+    STK_VIRT_DTOR ~Semaphore()
     {
         STK_ASSERT(m_wait_list.IsEmpty()); // API contract: must not be destroyed with waiting tasks
     }
 
     /*! \brief     Wait for a signal (decrement counter).
-        \param[in] timeout: Maximum time to wait (ticks).
+        \param[in] timeout_ticks: Maximum time to wait (ticks).
         \warning   ISR-safe only with \a timeout = \c NO_WAIT, ISR-unsafe otherwise.
         \return    True if acquired, false if timeout occurred.
     */
-    bool Wait(Timeout timeout = WAIT_INFINITE);
+    bool Wait(Timeout timeout_ticks = WAIT_INFINITE);
 
     /*! \brief     Poll the semaphore without blocking (decrement counter if available).
         \details   Checks if a resource token is available. If so, decrements the counter
@@ -127,28 +127,34 @@ private:
 // Wait
 // ---------------------------------------------------------------------------
 
-inline bool Semaphore::Wait(Timeout timeout)
+inline bool Semaphore::Wait(Timeout timeout_ticks)
 {
     ScopedCriticalSection cs_;
+    bool success = false;
 
     // fast path: resource is available
     if (m_count != 0U)
     {
         m_count = static_cast<uint16_t>(m_count - 1U);
         __stk_full_memfence();
-        return true;
+        success = true;
+    }
+    // slow path: block until Signal() or timeout
+    else if (timeout_ticks != NO_WAIT)
+    {
+        STK_ASSERT(!hw::IsInsideISR()); // API contract: caller must not be in ISR if timeout_ticks!=NO_WAIT
+
+        // note: after waking, if not a timeout, we effectively own the resource that Signal() produced
+        // but didn't put into m_count (see logic of if (m_wait_list.IsEmpty()) in Signal())
+        success = !IKernelService::GetInstance()->Wait(this, &cs_, timeout_ticks)->IsTimeout();
+    }
+    // try lock behavior (timeout_ticks=NO_WAIT)
+    else
+    {
+        // success is false already, noop
     }
 
-    // try lock behavior (timeout=NO_WAIT)
-    if (timeout == NO_WAIT)
-        return false;
-
-    STK_ASSERT(!hw::IsInsideISR()); // API contract: caller must not be in ISR if timeout!=NO_WAIT
-
-    // slow path: block until Signal() or timeout
-    // note: after waking, if not a timeout, we effectively own the resource that Signal() produced
-    // but didn't put into m_count (see logic of if (m_wait_list.IsEmpty()) in Signal())
-    return !IKernelService::GetInstance()->Wait(this, &cs_, timeout)->IsTimeout();
+    return success;
 }
 
 // ---------------------------------------------------------------------------
@@ -157,7 +163,7 @@ inline bool Semaphore::Wait(Timeout timeout)
 
 inline void Semaphore::Signal()
 {
-    ScopedCriticalSection cs_;
+    const ScopedCriticalSection cs_;
 
     if (m_wait_list.IsEmpty())
     {

--- a/stk/include/sync/stk_sync_spinlock.h
+++ b/stk/include/sync/stk_sync_spinlock.h
@@ -63,7 +63,7 @@ public:
                   An assertion is triggered in debug builds.
         \note     MISRA deviation: [STK-DEV-005] Rule 10-3-2.
     */
-    ~SpinLock()
+    STK_VIRT_DTOR ~SpinLock()
     {
         STK_ASSERT(m_owner_tid == TID_NONE); // API contract: lock must not be destroyed while held
     }
@@ -110,7 +110,7 @@ private:
 
 inline void SpinLock::Lock()
 {
-    TId current_tid = GetTid();
+    const TId current_tid = GetTid();
 
     // increase recursion if this thread already owns the lock
     if (!LockRecursively(current_tid))
@@ -126,18 +126,23 @@ inline void SpinLock::Lock()
 
 inline bool SpinLock::TryLock()
 {
-    TId current_tid = GetTid();
+    const TId current_tid = GetTid();
+    bool success = true;
 
     // increase recursion if this thread already owns the lock
     if (!LockRecursively(current_tid))
     {
         if (!m_lock.TryLock())
-            return false;
-
-        MakeLocked(current_tid);
+        {
+            success = false;
+        }
+        else
+        {
+            MakeLocked(current_tid);
+        }
     }
 
-    return true;
+    return success;
 }
 
 // ---------------------------------------------------------------------------
@@ -165,15 +170,17 @@ inline void SpinLock::Unlock()
 
 inline bool SpinLock::LockRecursively(TId locking_tid)
 {
+    bool success = false;
+  
     if ((m_owner_tid == locking_tid) && (m_recursion_count != 0U))
     {
         STK_ASSERT(m_recursion_count < RECURSION_MAX); // API contract: caller must not exceed max recursion depth
 
         ++m_recursion_count;
-        return true;
+        success = true;
     }
 
-    return false;
+    return success;
 }
 
 // ---------------------------------------------------------------------------
@@ -185,7 +192,9 @@ inline void SpinLock::MakeLocked(TId locking_tid)
     // kernel invariant: if either condition is false, the low-level lock and the
     // recursion counter are out of sync, this is an internal defect, not a caller error
     if ((m_owner_tid != TID_NONE) || (m_recursion_count != 0U))
+    {
         STK_KERNEL_PANIC(KERNEL_PANIC_ASSERT);
+    }
 
     m_owner_tid       = locking_tid;
     m_recursion_count = 1U;

--- a/stk/include/time/stk_time_timer.h
+++ b/stk/include/time/stk_time_timer.h
@@ -141,13 +141,15 @@ public:
     public:
         /*! \brief     Default constructor.
         */
-        explicit Timer() : m_deadline(0), m_timestamp(0), m_period(0U), m_active(false), m_pending(false), m_rearming(false)
+        explicit Timer() 
+            : m_deadline(0), m_timestamp(0), m_period(0U), m_active(false), 
+              m_pending(false), m_rearming(false)
         {}
 
         /*! \brief     Destructor.
             \note      MISRA deviation: [STK-DEV-005] Rule 10-3-2.
         */
-        ~Timer() = default;
+        STK_VIRT_DTOR ~Timer() = default;
 
         /*! \brief     Callback invoked by the handler task when this timer expires.
             \param[in] host: Pointer to the TimerHost that fired this timer.
@@ -198,19 +200,15 @@ public:
         uint32_t      m_period;    //!< reload period in ticks (0 = one-shot)
         volatile bool m_active;    //!< true if active
         volatile bool m_pending;   //!< true if pending to be handled
-        volatile bool m_rearming;  //!< true while a CMD_RESTART / CMD_START_OR_RESET is already in the command queue.
-                                   //!< Written by ISR/caller in PushCommand; cleared by tick task in ProcessCommands
-                                   //!< before executing the command so that a subsequent ISR edge can queue exactly
-                                   //!< one more coalesced command. Prevents unbounded queue growth when a noisy
-                                   //!< source (e.g. a bouncing button) fires the ISR faster than the tick task drains
-                                   //!< the command queue.
+        volatile bool m_rearming;  //!< true while a CMD_RESTART / CMD_START_OR_RESET is already in the command queue
     };
 
     /*! \brief Default constructor. Zero-initializes all internal state.
         \note  Call Initialize() before using any other member function.
     */
-    explicit TimerHost()
-        : m_task_tick_memory(), m_task_handler_memory(), m_task_tick(), m_task_process(), m_active(), m_now(0)
+    explicit TimerHost() 
+      : m_task_tick_memory(), m_task_handler_memory(), m_task_tick(), m_task_process(), 
+        m_active(), m_now(0)
     {}
 
     /*! \brief Destructor.
@@ -225,27 +223,27 @@ public:
     void Initialize(IKernel *kernel, EAccessMode mode);
 
     /*! \brief     Start timer.
-        \param[in] timer: Timer instance. Must not already be active.
+        \param[in] tmr: Timer instance. Must not already be active.
         \param[in] delay: Initial delay in ticks before first expiration.
         \param[in] period: Reload period in ticks (0 is one-shot timer).
         \return    True on success, false if timer is already active or command queue is full.
     */
-    bool Start(Timer &timer, uint32_t delay, uint32_t period = 0);
+    bool Start(Timer &tmr, uint32_t delay, uint32_t period = 0);
 
     /*! \brief     Stop running timer.
-        \param[in] timer: Timer instance. Must be active.
+        \param[in] tmr: Timer instance. Must be active.
         \return    True on success, false if timer is not active or command queue is full.
     */
-    bool Stop(Timer &timer);
+    bool Stop(Timer &tmr);
 
     /*! \brief     Reset periodic timer's deadline.
-        \param[in] timer: Timer instance. Must be active and periodic.
+        \param[in] tmr: Timer instance. Must be active and periodic.
         \return    True on success, false if timer is not active, not periodic, or command queue is full.
     */
-    bool Reset(Timer &timer);
+    bool Reset(Timer &tmr);
 
     /*! \brief     Atomically stop and re-start timer.
-        \param[in] timer: Timer instance (active or inactive).
+        \param[in] tmr: Timer instance (active or inactive).
         \param[in] delay: Initial delay in ticks before first expiration.
         \param[in] period: Reload period in ticks (0 is one-shot timer).
         \return    True on success, false if command queue is full.
@@ -255,10 +253,10 @@ public:
                    Useful for watchdog refresh and debounce reset patterns.
                    Safe to call regardless of whether the timer is currently active.
     */
-    bool Restart(Timer &timer, uint32_t delay, uint32_t period = 0);
+    bool Restart(Timer &tmr, uint32_t delay, uint32_t period = 0);
 
     /*! \brief     Start timer if inactive, or reset its deadline if already active and periodic.
-        \param[in] timer: Timer instance (active or inactive).
+        \param[in] tmr: Timer instance (active or inactive).
         \param[in] delay: Initial delay in ticks (used only when starting).
         \param[in] period: Reload period in ticks (used only when starting, 0 is one-shot).
         \return    True on success, false if command queue is full.
@@ -270,7 +268,7 @@ public:
                    If the timer is active but one-shot, no action is taken (a one-shot
                    timer mid-flight cannot be reset; use Restart() instead).
     */
-    bool StartOrReset(Timer &timer, uint32_t delay, uint32_t period = 0);
+    bool StartOrReset(Timer &tmr, uint32_t delay, uint32_t period = 0);
 
     /*! \brief     Change the period of a running periodic timer without affecting its current deadline.
         \param[in] timer: Timer instance. Must be active and periodic.
@@ -281,7 +279,7 @@ public:
                    fires. To apply the new period immediately (restart from now), call
                    Reset() after SetPeriod().
     */
-    bool SetPeriod(Timer &timer, uint32_t period);
+    bool SetPeriod(Timer &tmr, uint32_t period);
 
     /*! \brief    Return true if no timers are currently active.
         \return   True if active timer count is zero.
@@ -328,7 +326,8 @@ private:
     public:
         /*! \brief Default constructor. All members are zero/null-initialized. */
         explicit TimerWorkerTask()
-            : m_func(nullptr), m_host(nullptr), m_stack(nullptr), m_stack_size(0), m_mode(ACCESS_USER), m_weight(0)
+            : m_func(nullptr), m_host(nullptr), m_stack(nullptr), m_stack_size(0U), 
+              m_mode(ACCESS_USER), m_weight(DEFAULT_WEIGHT)
         {}
 
         // ITask
@@ -351,7 +350,8 @@ private:
             \param[in] func: Entry function called in the task's context.
             \note  Must be called before the task is added to the kernel.
         */
-        void Initialize(TimerHost *host, Word *stack, size_t stack_size, EAccessMode mode, TimerFuncType func)
+        void Initialize(TimerHost *host, Word *stack, size_t stack_size, EAccessMode mode, 
+                        TimerFuncType const func)
         {
             m_host       = host;
             m_func       = func;
@@ -471,18 +471,22 @@ private:
 
 inline uint32_t TimerHost::Timer::GetRemainingTicks() const
 {
+    uint32_t remaining_ticks = 0U;
+
     if (m_active)
     {
         // if deadline has passed but not yet been processed by the tick task,
         // remaining would be negative, result fits in uint32_t because delay and
         // period are uint32_t, so remaining time is bounded by uint32_t max
         const Ticks remaining = m_deadline - GetTicks();
-        return (remaining > 0 ? static_cast<uint32_t>(remaining) : 0);
+        
+        if (remaining > 0)
+        {
+            remaining_ticks = static_cast<uint32_t>(remaining);
+        }
     }
-    else
-    {
-        return 0;
-    }
+
+    return remaining_ticks;
 }
 
 // ---------------------------------------------------------------------------
@@ -511,89 +515,88 @@ inline void TimerHost::Initialize(IKernel *kernel, EAccessMode mode)
 // Start
 // ---------------------------------------------------------------------------
 
-inline bool TimerHost::Start(Timer &timer, uint32_t delay, uint32_t period)
+inline bool TimerHost::Start(Timer &tmr, uint32_t delay, uint32_t period)
 {
     STK_ASSERT(delay <= static_cast<uint32_t>(WAIT_INFINITE));
     STK_ASSERT((period == 0U) || (period <= static_cast<uint32_t>(WAIT_INFINITE)));
+    
+    // duplicate attempt to start already started timer is not an error (ignore)
+    bool success = true;
 
     // timer must not already be active
-    if (!timer.m_active)
+    if (!tmr.m_active)
     {
-        return PushCommand({
+        success = PushCommand({
             .cmd       = TimerCommand::CMD_START,
-            .timer     = &timer,
+            .timer     = &tmr,
             .timestamp = GetTicks(),
             .delay     = delay,
             .period    = period
         });
     }
-    else
-    {
-        // duplicate attempt to start already started timer is not an error (ignore)
-        return true;
-    }
+
+    return success;
 }
 
 // ---------------------------------------------------------------------------
 // Stop
 // ---------------------------------------------------------------------------
 
-inline bool TimerHost::Stop(Timer &timer)
+inline bool TimerHost::Stop(Timer &tmr)
 {
+    // duplicate attempt to stop already stopped timer is not an error (ignore)
+    bool success = true;
+  
     // timer must be active
-    if (timer.m_active)
+    if (tmr.m_active)
     {
-        return PushCommand({
+        success = PushCommand({
             .cmd       = TimerCommand::CMD_STOP,
-            .timer     = &timer,
+            .timer     = &tmr,
             .timestamp = 0,
             .delay     = 0U,
             .period    = 0U
         });
     }
-    else
-    {
-        // duplicate attempt to stop already stopped timer is not an error (ignore)
-        return true;
-    }
+
+    return success;
 }
 
 // ---------------------------------------------------------------------------
 // Reset
 // ---------------------------------------------------------------------------
 
-inline bool TimerHost::Reset(Timer &timer)
+inline bool TimerHost::Reset(Timer &tmr)
 {
+    bool success = false;
+  
     // timer must be active and periodic
-    if (timer.m_active && (timer.m_period != 0U))
+    if (tmr.m_active && (tmr.m_period != 0U))
     {
-        return PushCommand({
+        success = PushCommand({
             .cmd       = TimerCommand::CMD_RESET,
-            .timer     = &timer,
+            .timer     = &tmr,
             .timestamp = GetTicks(),
             .delay     = 0U,
             .period    = 0U
         });
     }
-    else
-    {
-        // unexpected reset command
-        return false;
-    }
+
+    return success;
 }
 
 // ---------------------------------------------------------------------------
 // Restart
 // ---------------------------------------------------------------------------
 
-inline bool TimerHost::Restart(Timer &timer, uint32_t delay, uint32_t period)
+inline bool TimerHost::Restart(Timer &tmr, uint32_t delay, uint32_t period)
 {
     STK_ASSERT(delay <= static_cast<uint32_t>(WAIT_INFINITE));
     STK_ASSERT((period == 0U) || (period <= static_cast<uint32_t>(WAIT_INFINITE)));
 
     return PushCommand({
         .cmd       = TimerCommand::CMD_RESTART,
-        .timer     = &timer,
+        .timer     = &tmr,
         .timestamp = GetTicks(),
         .delay     = delay,
         .period    = period
@@ -604,14 +607,14 @@ inline bool TimerHost::Restart(Timer &timer, uint32_t delay, uint32_t period)
 // StartOrReset
 // ---------------------------------------------------------------------------
 
-inline bool TimerHost::StartOrReset(Timer &timer, uint32_t delay, uint32_t period)
+inline bool TimerHost::StartOrReset(Timer &tmr, uint32_t delay, uint32_t period)
 {
     STK_ASSERT(delay <= static_cast<uint32_t>(WAIT_INFINITE));
     STK_ASSERT((period == 0U) || (period <= static_cast<uint32_t>(WAIT_INFINITE)));
 
     return PushCommand({
         .cmd       = TimerCommand::CMD_START_OR_RESET,
-        .timer     = &timer,
+        .timer     = &tmr,
         .timestamp = GetTicks(),
         .delay     = delay,
         .period    = period
@@ -622,25 +625,25 @@ inline bool TimerHost::StartOrReset(Timer &timer, uint32_t delay, uint32_t perio
 // SetPeriod
 // ---------------------------------------------------------------------------
 
-inline bool TimerHost::SetPeriod(Timer &timer, uint32_t period)
+inline bool TimerHost::SetPeriod(Timer &tmr, uint32_t period)
 {
+    bool success = false;
+  
     // period == 0 is rejected: it would silently convert a periodic timer
     // to one-shot semantics, which is better expressed via Stop() + Start()
-    if (timer.m_active && (timer.m_period != 0U) && (period != 0U) &&
+    if (tmr.m_active && (tmr.m_period != 0U) && (period != 0U) &&
         (period <= static_cast<uint32_t>(WAIT_INFINITE)))
     {
-        return PushCommand({
+        success = PushCommand({
             .cmd       = TimerCommand::CMD_SET_PERIOD,
-            .timer     = &timer,
+            .timer     = &tmr,
             .timestamp = 0,
             .delay     = 0U,
             .period    = period
         });
     }
-    else
-    {
-        return false;
-    }
+
+    return success;
 }
 
 // ---------------------------------------------------------------------------
@@ -669,38 +672,37 @@ inline void TimerHost::UpdateTime()
     while (ProcessCommands(next_sleep))
     {
         next_sleep = WAIT_INFINITE;
-
         const Ticks now = GetTicks();
 
         // using WriteVolatile64() to guarantee correct lockless reading order by ReadVolatile64
         hw::WriteVolatile64(&m_now, now);
 
-        Timer *timer = static_cast<Timer *>(m_active.GetFirst());
-        while (timer != nullptr)
+        Timer *tmr = static_cast<Timer *>(m_active.GetFirst());
+        while (tmr != nullptr)
         {
-            Timer *next = static_cast<Timer *>(timer->GetNext());
+            Timer *const next = static_cast<Timer *>(tmr->GetNext());
 
-            if (timer->m_active)
+            if (tmr->m_active)
             {
                 // check if still pending to be handled
-                if (!timer->m_pending)
+                if (!tmr->m_pending)
                 {
                     bool one_shot = false;
-                    const Ticks diff = now - timer->m_deadline;
+                    const Ticks diff = now - tmr->m_deadline;
 
                     if (diff >= 0)
                     {
                         // set timestamp at which timer expired
-                        timer->m_timestamp = now;
+                        tmr->m_timestamp = now;
 
                         // avoid updating timer again before it was handled
-                        timer->m_pending = true;
+                        tmr->m_pending = true;
 
                         // periodic
-                        if (timer->m_period != 0U)
+                        if (tmr->m_period != 0U)
                         {
                             // reload (use now to avoid drift accumulation)
-                            timer->m_deadline = now + static_cast<Ticks>(timer->m_period) - diff;
+                            tmr->m_deadline = now + static_cast<Ticks>(tmr->m_period) - diff;
                         }
                         // one-shot
                         else
@@ -708,22 +710,22 @@ inline void TimerHost::UpdateTime()
                             one_shot = true;
 
                             // remove from active timers
-                            m_active.Unlink(timer);
+                            m_active.Unlink(tmr);
 
                             // mark as inactive (must follow Unlink)
-                            timer->m_active = false;
+                            tmr->m_active = false;
                         }
 
                         __stk_full_memfence();
 
                         // push to the handling queue
-                        m_queue.Write(timer);
+                        STK_UNUSED(m_queue.Write(tmr));
                     }
 
                     // one-shot timer does not affect next_sleep
                     if (!one_shot)
                     {
-                        Timeout next_deadline = static_cast<Timeout>(timer->m_deadline - now);
+                        const Timeout next_deadline = static_cast<Timeout>(tmr->m_deadline - now);
                         STK_ASSERT(next_deadline > 0);
 
                         if ((next_deadline > 0) && (next_deadline < next_sleep))
@@ -736,17 +738,17 @@ inline void TimerHost::UpdateTime()
             else
             {
                 // could be stopped externally, remove from active timers
-                m_active.Unlink(timer);
+                m_active.Unlink(tmr);
             }
 
-            timer = next;
+            tmr = next;
         }
     }
 
     // unlink all timers on shutdown
-    while (Timer::DLEntryType *timer = m_active.GetFirst())
+    while (Timer::DLEntryType *const tmr = m_active.GetFirst())
     {
-        m_active.Unlink(timer);
+        m_active.Unlink(tmr);
     }
 }
 
@@ -756,20 +758,29 @@ inline void TimerHost::UpdateTime()
 
 inline void TimerHost::ProcessTimers()
 {
-    Timer *timer = nullptr;
+    Timer *tmr = nullptr;
     bool keep_running = true;
 
-    while (keep_running && m_queue.Read(timer))
+    while (keep_running)
     {
+        if (!m_queue.Read(tmr))
+        {
+            break; // no pending timers available
+        }
+      
         // nullptr is the shutdown sentinel pushed by CMD_SHUTDOWN
-        if (timer == nullptr)
+        if (tmr == nullptr)
         {
             keep_running = false;
         }
-        else if (timer->m_pending)
+        else if (tmr->m_pending)
         {
-            timer->m_pending = false;
-            timer->OnExpired(this);
+            tmr->m_pending = false;
+            tmr->OnExpired(this);
+        }
+        else
+        {
+            // noop
         }
     }
 }
@@ -781,169 +792,178 @@ inline void TimerHost::ProcessTimers()
 inline bool TimerHost::ProcessCommands(Timeout next_sleep)
 {
     TimerCommand cmd = {};
+    bool working = true;
 
     // if nothing is active, sleep indefinitely until a command arrives
-    next_sleep = (m_active.IsEmpty() ? WAIT_INFINITE : next_sleep);
+    if (m_active.IsEmpty())
+    {
+        next_sleep = WAIT_INFINITE;
+    }
 
-    while (m_commands.Read(cmd, next_sleep))
+    while (working && m_commands.Read(cmd, next_sleep))
     {
         switch (cmd.cmd)
         {
-        case TimerCommand::CMD_START:
+        case TimerCommand::CMD_START: 
         {
-            Timer *timer = cmd.timer;
-            STK_ASSERT(timer != nullptr);
+            Timer *const tmr = cmd.timer;
+            STK_ASSERT(tmr != nullptr);
 
             // reject if already active or linked (double-start)
-            if (!timer->m_active)
+            if (!tmr->m_active)
             {
-                STK_ASSERT(!timer->IsLinked());
+                STK_ASSERT(!tmr->IsLinked());
 
-                timer->m_deadline = cmd.timestamp + cmd.delay;
-                timer->m_period   = cmd.period;
-                timer->m_active   = true;
-                timer->m_pending  = false;
+                tmr->m_deadline = cmd.timestamp + static_cast<Ticks>(cmd.delay);
+                tmr->m_period   = cmd.period;
+                tmr->m_active   = true;
+                tmr->m_pending  = false;
 
-                m_active.LinkBack(timer);
+                m_active.LinkBack(tmr);
                 next_sleep = NO_WAIT;
             }
-        }
-        break;
+            
+        break; }
 
         case TimerCommand::CMD_STOP:
         {
-            Timer *timer = cmd.timer;
-            STK_ASSERT(timer != nullptr);
+            Timer *const tmr = cmd.timer;
+            STK_ASSERT(tmr != nullptr);
 
-            timer->m_active  = false;
-            timer->m_pending = false;
+            tmr->m_active  = false;
+            tmr->m_pending = false;
 
             // allow possibly duplicate CMD_STOP as it is harmless for the logic
-            if (timer->IsLinked())
+            if (tmr->IsLinked())
             {
-                m_active.Unlink(timer);
+                m_active.Unlink(tmr);
             }
-        }
-        break;
+            
+        break; }
 
         case TimerCommand::CMD_RESET:
         {
-            Timer *timer = cmd.timer;
-            STK_ASSERT(timer != nullptr);
+            Timer *const tmr = cmd.timer;
+            STK_ASSERT(tmr != nullptr);
 
             // only reset if still active and periodic
-            if (timer->m_active && (timer->m_period != 0U))
+            if (tmr->m_active && (tmr->m_period != 0U))
             {
-                STK_ASSERT(timer->GetHead() == &m_active);
+                STK_ASSERT(tmr->GetHead() == &m_active);
 
-                timer->m_deadline = cmd.timestamp + timer->m_period;
-                timer->m_pending  = false;
+                tmr->m_deadline = cmd.timestamp + static_cast<Ticks>(tmr->m_period);
+                tmr->m_pending  = false;
 
                 next_sleep = NO_WAIT;
             }
-        }
-        break;
+            
+        break; }
 
         case TimerCommand::CMD_RESTART:
         {
             // atomic stop + re-start: no precondition on current timer state
-            Timer *timer = cmd.timer;
-            STK_ASSERT(timer != nullptr);
+            Timer *const tmr = cmd.timer;
+            STK_ASSERT(tmr != nullptr);
 
             // unlink if currently in the active list
-            if (timer->IsLinked())
+            if (tmr->IsLinked())
             {
-                m_active.Unlink(timer);
+                m_active.Unlink(tmr);
             }
 
             // re-arm with fresh parameters
-            timer->m_deadline = cmd.timestamp + cmd.delay;
-            timer->m_period   = cmd.period;
-            timer->m_active   = true;
-            timer->m_pending  = false;
-            timer->m_rearming = false;
+            tmr->m_deadline = cmd.timestamp + static_cast<Ticks>(cmd.delay);
+            tmr->m_period   = cmd.period;
+            tmr->m_active   = true;
+            tmr->m_pending  = false;
+            tmr->m_rearming = false;
 
             // re-link to the back of the list
-            m_active.LinkBack(timer);
+            m_active.LinkBack(tmr);
             next_sleep = NO_WAIT;
-        }
-        break;
+            
+        break; }
 
         case TimerCommand::CMD_START_OR_RESET:
         {
-            Timer *timer = cmd.timer;
-            STK_ASSERT(timer != nullptr);
+            Timer *const tmr = cmd.timer;
+            STK_ASSERT(tmr != nullptr);
 
             // not currently active: start with supplied parameters
-            if (!timer->m_active)
+            if (!tmr->m_active)
             {
-                STK_ASSERT(!timer->IsLinked());
+                STK_ASSERT(!tmr->IsLinked());
 
-                timer->m_deadline = cmd.timestamp + cmd.delay;
-                timer->m_period   = cmd.period;
-                timer->m_active   = true;
-                timer->m_pending  = false;
-                timer->m_rearming = false;
+                tmr->m_deadline = cmd.timestamp + static_cast<Ticks>(cmd.delay);
+                tmr->m_period   = cmd.period;
+                tmr->m_active   = true;
+                tmr->m_pending  = false;
+                tmr->m_rearming = false;
 
-                m_active.LinkBack(timer);
+                m_active.LinkBack(tmr);
             }
             // active and periodic: reset deadline anchored to call-site timestamp
-            else if (timer->m_period != 0U)
+            else if (tmr->m_period != 0U)
             {
-                STK_ASSERT(timer->GetHead() == &m_active);
+                STK_ASSERT(tmr->GetHead() == &m_active);
 
-                timer->m_deadline = cmd.timestamp + timer->m_period;
-                timer->m_pending  = false;
+                tmr->m_deadline = cmd.timestamp + static_cast<Ticks>(tmr->m_period);
+                tmr->m_pending  = false;
+            }
+            else
+            {
+                // noop
             }
 
-            // active one-shot: no action — cannot reset a one-shot mid-flight,
+            // active one-shot: no action - cannot reset a one-shot mid-flight,
             // caller should use Restart() if unconditional re-arm is needed
 
             next_sleep = NO_WAIT;
-        }
-        break;
+            
+        break; }
 
         case TimerCommand::CMD_SET_PERIOD:
         {
-            Timer *timer = cmd.timer;
-            STK_ASSERT(timer != nullptr);
+            Timer *const tmr = cmd.timer;
+            STK_ASSERT(tmr != nullptr);
             STK_ASSERT(cmd.period != 0U);
 
             // guard: only apply if still active and periodic
-            if (timer->m_active && (timer->m_period != 0U))
+            if (tmr->m_active && (tmr->m_period != 0U))
             {
-                STK_ASSERT(timer->GetHead() == &m_active);
+                STK_ASSERT(tmr->GetHead() == &m_active);
 
                 // new period takes effect on the next reload, current deadline is
                 // intentionally left unchanged so the in-flight interval is not
                 // truncated or extended, caller can follow up with Reset() if
                 // immediate application is required
-                timer->m_period = cmd.period;
+                tmr->m_period = cmd.period;
             }
-        }
-        break;
+            
+        break; }
 
         case TimerCommand::CMD_SHUTDOWN:
         {
             // wake all handler tasks with shutdown sentinels
             for (size_t i = 0U; i < STK_TIMER_THREADS_COUNT; ++i)
             {
-                m_queue.Write(nullptr, NO_WAIT);
+                STK_UNUSED(m_queue.Write(nullptr, NO_WAIT));
             }
 
             // signal UpdateTime() to exit its loop
-            return false;
-        }
+            working = false;
+            
+        break; }
 
         default:
         {
             STK_ASSERT(false);
-            break;
-        }
+            
+            break; }
         }
     }
 
-    return true;
+    return working;
 }
 
 // ---------------------------------------------------------------------------

--- a/stk/include/time/stk_time_util.h
+++ b/stk/include/time/stk_time_util.h
@@ -59,10 +59,12 @@ public:
                    The first Poll() firing will occur no earlier than \a period ticks
                    after construction.
     */
-    PeriodicTrigger(uint32_t period, bool start = false) : m_next(0U), m_period(period)
+    PeriodicTrigger(uint32_t period, bool start = false) : m_next(0), m_period(period)
     {
         if (start)
+        {
             Restart();
+        }
     }
 
     /*! \brief  Get currently configured trigger period.
@@ -90,7 +92,7 @@ public:
     */
     void Restart()
     {
-        m_next = GetTicks() + m_period;
+        m_next = GetTicks() + static_cast<Ticks>(m_period);
     }
 
     /*! \brief   Check whether the scheduled trigger time has been reached.
@@ -107,14 +109,16 @@ public:
     {
         STK_ASSERT(m_next > 0);
 
-        Ticks diff = GetTicks() - m_next;
+        bool triggered = false;
+        const Ticks diff = GetTicks() - m_next;
+
         if (diff >= 0)
         {
-            m_next += m_period;
-            return true;
+            m_next += static_cast<Ticks>(m_period);
+            triggered = true;
         }
 
-        return false;
+        return triggered;
     }
 
 protected:

--- a/stk/src/arch/arm/cortex-m/stk_arch_arm-cortex-m.cpp
+++ b/stk/src/arch/arm/cortex-m/stk_arch_arm-cortex-m.cpp
@@ -20,34 +20,7 @@
 #include "stk.h"
 #include "stk_arch.h"
 #include "arch/stk_arch_common.h"
-
-#ifdef __ICCARM__
-    #include <atomic>
-
-    #define __ATOMIC_RELAXED std::memory_order_relaxed
-    #define __ATOMIC_CONSUME std::memory_order_consume
-    #define __ATOMIC_ACQUIRE std::memory_order_acquire
-    #define __ATOMIC_RELEASE std::memory_order_release
-    #define __ATOMIC_ACQ_REL std::memory_order_acq_rel
-    #define __ATOMIC_SEQ_CST std::memory_order_seq_cst
-
-    #define __atomic_test_and_set(ptr, memorder) \
-        (reinterpret_cast<volatile std::atomic_flag *>(ptr)->test_and_set(memorder))
-
-    #define __atomic_clear(ptr, memorder) \
-        (reinterpret_cast<volatile std::atomic_flag *>(ptr)->clear(memorder))
-#endif
-          
-#ifdef __ICCARM__
-    #define STK_ASM_SYNTAX_UNIFIED      /* IAR: not needed, unified is default */
-    #define STK_ASM_POOL                /* IAR: not needed, handled automatically */
-    #define STK_ASM_ALIGN_2             /* IAR: not needed */
-#else
-    #define STK_ASM_SYNTAX_UNIFIED      ".syntax unified             \n"
-    #define STK_ASM_POOL                ".pool                       \n"
-    #define STK_ASM_ALIGN_2             ".align 2                    \n"
-#endif
-
+         
 using namespace stk;
 
 //! Do sanity check for a compiler define, __CORTEX_M must be defined.
@@ -72,37 +45,37 @@ using namespace stk;
 #define STK_CORTEX_M_MANAGE_LR (__CORTEX_M >= 3U)
 
 // Non-Secure (and pre-ARMv8-M) EXC_RETURN values -- S bit (bit 6) = 0.
-#define STK_CORTEX_M_EXC_RETURN_HANDLR_MSP 0xFFFFFFF1U // Handler mode, MSP stack (Non-Secure)
-#define STK_CORTEX_M_EXC_RETURN_THREAD_MSP 0xFFFFFFF9U // Thread mode, MSP stack (Non-Secure)
-#define STK_CORTEX_M_EXC_RETURN_THREAD_PSP 0xFFFFFFFDU // Thread mode, PSP stack (Non-Secure)
+#define STK_CORTEX_M_EXC_RETURN_HANDLR_MSP (0xFFFFFFF1U) // Handler mode, MSP stack (Non-Secure)
+#define STK_CORTEX_M_EXC_RETURN_THREAD_MSP (0xFFFFFFF9U) // Thread mode, MSP stack (Non-Secure)
+#define STK_CORTEX_M_EXC_RETURN_THREAD_PSP (0xFFFFFFFDU) // Thread mode, PSP stack (Non-Secure)
 
 // ARMv8-M TrustZone Secure EXC_RETURN values -- S bit (bit 6) = 1.
 // These are only meaningful when _STK_CORTEX_M_TRUSTZONE is defined on M23/M33+.
 // Reference: ARMv8-M Architecture Reference Manual, section B1.5.8.
-#define STK_CORTEX_M_EXC_RETURN_S_HANDLR_MSP  0xFFFFFFE1U // Secure, Handler mode, MSP
-#define STK_CORTEX_M_EXC_RETURN_S_THREAD_MSP  0xFFFFFFE9U // Secure, Thread mode, MSP
-#define STK_CORTEX_M_EXC_RETURN_S_THREAD_PSP  0xFFFFFFEDU // Secure, Thread mode, PSP
+#define STK_CORTEX_M_EXC_RETURN_S_HANDLR_MSP  (0xFFFFFFE1U) // Secure, Handler mode, MSP
+#define STK_CORTEX_M_EXC_RETURN_S_THREAD_MSP  (0xFFFFFFE9U) // Secure, Thread mode, MSP
+#define STK_CORTEX_M_EXC_RETURN_S_THREAD_PSP  (0xFFFFFFEDU) // Secure, Thread mode, PSP
 // Non-Secure return with Non-Secure FPU state saved (used for NS tasks on M33 with FPU).
-#define STK_CORTEX_M_EXC_RETURN_NS_THREAD_PSP 0xFFFFFFBCU // Non-Secure, Thread, PSP, NS-FPU
+#define STK_CORTEX_M_EXC_RETURN_NS_THREAD_PSP (0xFFFFFFBCU) // Non-Secure, Thread, PSP, NS-FPU
 
 //! Bit 6 of EXC_RETURN: 1 = Secure stack, 0 = Non-Secure stack (ARMv8-M only).
-#define STK_CORTEX_M_EXC_RETURN_S_BIT         0x00000040U
+#define STK_CORTEX_M_EXC_RETURN_S_BIT         (0x00000040U)
 
-#define STK_CORTEX_M_ISR_PRIORITY_HIGHEST  0
-#define STK_CORTEX_M_ISR_PRIORITY_LOWEST   0xFF
+#define STK_CORTEX_M_ISR_PRIORITY_HIGHEST  (0U)
+#define STK_CORTEX_M_ISR_PRIORITY_LOWEST   (0xFFU)
 
 //! Number of registers kept in stack.
 #if STK_CORTEX_M_MANAGE_LR
-    #define STK_CORTEX_M_REGISTER_COUNT 17
+    #define STK_CORTEX_M_REGISTER_COUNT (17U)
 #else
-    #define STK_CORTEX_M_REGISTER_COUNT 16
+    #define STK_CORTEX_M_REGISTER_COUNT (16U)
 #endif
 
 //! Additional words pushed onto the stack when TrustZone is active (PSPLIM + PSPLIM_NS).
 #if 0//defined(_STK_CORTEX_M_TRUSTZONE) && (__CORTEX_M >= 33U)
-    #define STK_CORTEX_M_TZ_REGISTER_COUNT 2
+    #define STK_CORTEX_M_TZ_REGISTER_COUNT (2U)
 #else
-    #define STK_CORTEX_M_TZ_REGISTER_COUNT 0
+    #define STK_CORTEX_M_TZ_REGISTER_COUNT (0U)
 #endif
 
 //! Total words reserved at the top of each task stack.
@@ -123,11 +96,22 @@ using namespace stk;
 #ifndef STK_SVC_HANDLER
     #define STK_SVC_HANDLER SVC_Handler
 #endif
+      
+// Inline ASM helpers:
+#ifdef __ICCARM__
+    #define STK_ASM_SYNTAX_UNIFIED      /* IAR: not needed, unified is default */
+    #define STK_ASM_POOL                /* IAR: not needed, handled automatically */
+    #define STK_ASM_ALIGN_2             /* IAR: not needed */
+#else
+    #define STK_ASM_SYNTAX_UNIFIED      ".syntax unified             \n"
+    #define STK_ASM_POOL                ".pool                       \n"
+    #define STK_ASM_ALIGN_2             ".align 2                    \n"
+#endif
 
 //! SVC commands.
 enum ESvcCommandId : uint8_t
 {
-    SVC_START_SCHEDULING = 0,
+    SVC_START_SCHEDULING = 0U,
     SVC_ENTER_CRITICAL,
     SVC_EXIT_CRITICAL,
     //SVC_FORCE_SWITCH
@@ -154,9 +138,9 @@ struct TrustZoneFrame
     Word PSPLIM;    //!< Secure PSPLIM register value.
     Word PSPLIM_NS; //!< Non-Secure PSPLIM register value.
 };
-#define STK_CORTEX_M_TRUSTZONE_FRAME 1
+#define STK_CORTEX_M_TRUSTZONE_FRAME (1)
 #else
-#define STK_CORTEX_M_TRUSTZONE_FRAME 0
+#define STK_CORTEX_M_TRUSTZONE_FRAME (0)
 #endif
 
 /*! \struct ExceptionFrame
@@ -260,7 +244,7 @@ __stk_attr_naked Word HW_SVCEnterCritical()
 #pragma diag_suppress=Pe940
     // return value is passed in r0 by the SVC handler per AAPCS;
     // IAR cannot see this through the naked asm, suppress the warning.
-    return 0;
+    return 0U;
 #pragma diag_default=Pe940
 #endif
 }
@@ -323,9 +307,9 @@ static __stk_forceinline bool HW_InterruptsDisabled()
 #if (defined(__clang__) && defined(__ARMCOMPILER_VERSION)) || defined(__ICCARM__)
     Word primask;
     __asm volatile("MRS %0, primask" : "=r"(primask));
-    return (primask & 1U);
+    return ((primask & 1U) != 0U);
 #else
-    return (__get_PRIMASK() & 1U);
+    return ((__get_PRIMASK() & 1U) != 0U);
 #endif
 }
 
@@ -365,6 +349,36 @@ static __stk_forceinline void HW_EnterSleepMode()
     __WFI();
 }
 
+// IAR wrappers for: __atomic_test_and_set, __atomic_clear.
+#ifdef __ICCARM__
+    #include <xatomic.h>
+
+    #define __ATOMIC_RELAXED __MEMORY_ORDER_RELAXED__
+    #define __ATOMIC_CONSUME __MEMORY_ORDER_CONSUME__
+    #define __ATOMIC_ACQUIRE __MEMORY_ORDER_ACQUIRE__
+    #define __ATOMIC_RELEASE __MEMORY_ORDER_RELEASE__
+    #define __ATOMIC_ACQ_REL __MEMORY_ORDER_ACQ_REL__
+    #define __ATOMIC_SEQ_CST __MEMORY_ORDER_SEQ_CST__
+
+    static __stk_forceinline bool __atomic_test_and_set(volatile bool *ptr, int memorder)
+    {
+    #ifdef __ICCARM__
+      STK_STATIC_ASSERT(sizeof(std::__iar_atomic_flag) == sizeof(bool));
+    #endif
+      
+        return std::__iar_atomic_flag_test_and_set(ptr, memorder);
+    }
+
+    static __stk_forceinline void __atomic_clear(volatile bool *ptr, int memorder)
+    {
+    #ifdef __ICCARM__
+      STK_STATIC_ASSERT(sizeof(std::__iar_atomic_flag) == sizeof(bool));
+    #endif
+      
+        std::__iar_atomic_flag_clear(ptr, memorder);
+    }
+#endif
+
 #ifdef CONTROL_nPRIV_Msk
 /*! \brief     Attempt to acquire a spin-lock without blocking (M3/M4/M7).
     \details   Uses a GCC built-in atomic test-and-set with acquire memory ordering,
@@ -379,11 +393,7 @@ static __stk_forceinline void HW_EnterSleepMode()
     \see       HW_SpinLockLock, HW_SpinLockUnlock
 */
 static __stk_forceinline bool HW_SpinLockTryLock(volatile bool &lock)
-{
-#ifdef __ICCARM__
-  STK_STATIC_ASSERT(sizeof(std::atomic_flag) == sizeof(bool));
-#endif
-      
+{     
     return !__atomic_test_and_set(&lock, __ATOMIC_ACQUIRE);
 }
 
@@ -401,8 +411,10 @@ static __stk_forceinline bool HW_SpinLockTryLock(volatile bool &lock)
 */
 static __stk_forceinline void HW_SpinLockUnlock(volatile bool &lock)
 { 
-    if (!lock)
+    if (lock == false)
+    {
         STK_KERNEL_PANIC(KERNEL_PANIC_SPINLOCK_DEADLOCK); // release attempt of unowned lock
+    }
 
     // ensure all data writes (like scheduling metadata) are flushed before the lock is released:
     // __atomic_clear with __ATOMIC_RELEASE provides the required store-release barrier,
@@ -540,10 +552,10 @@ static __stk_forceinline void HW_SpinLockUnlock(volatile bool &lock)
 */
 static __stk_forceinline void HW_SpinLockLock(volatile bool &lock)
 {
-    uint32_t timeout = 0xFFFFFF;
+    uint32_t timeout = 0xFFFFFFU;
     while (!HW_SpinLockTryLock(lock))
     {
-        if (--timeout == 0)
+        if (--timeout == 0U)
         {
             // invariant violated: the lock owner exited without releasing
             STK_KERNEL_PANIC(KERNEL_PANIC_SPINLOCK_DEADLOCK);
@@ -776,7 +788,7 @@ static __stk_forceinline void HW_EnableFullFpuAccess()
 {
 #if STK_CORTEX_M_FPU
     // enable FPU CP10/CP11 Secure and Non-secure register access
-    SCB->CPACR |= (0b11 << 20) | (0b11 << 22);
+    SCB->CPACR |= (static_cast<uint32_t>(0b11) << 20) | (static_cast<uint32_t>(0b11) << 22);
 #endif
 }
 
@@ -799,9 +811,9 @@ static __stk_forceinline void HW_ClearPendingSwitch()
 */
 static __stk_forceinline void HW_SysTickStart(uint32_t period_ticks)
 {
-    uint32_t result = SysTick_Config(static_cast<uint32_t>(ConvertTimeUsToClockCycles(HW_CoreClockFrequency(), period_ticks)));
+    const uint32_t result = SysTick_Config(static_cast<uint32_t>(ConvertTimeUsToClockCycles(HW_CoreClockFrequency(), period_ticks)));
     STK_ASSERT(result == 0U);
-    (void)result;
+    STK_UNUSED(result);
 
     // QEMU workaround (Launchpad Bug #1872237):
     // SysTick_Config() writes VAL=0 before setting ENABLE=1. On QEMU,
@@ -846,20 +858,22 @@ static __stk_forceinline uint32_t HW_SysTickValueAfterDisable()
     __DSB();
 
     // check for a QEMU case and discard elapsed result
-    uint32_t VAL = HW_SysTickValue();
-    if (VAL == 0)
-        VAL = SysTick->LOAD;
+    uint32_t val = HW_SysTickValue();
+    if (val == 0U)
+    {
+        val = SysTick->LOAD;
+    }
 
-    return VAL;
+    return val;
 }
 
 /*! \brief     Get number of elapsed ticks of the current period of SysTick timer peripheral.
-    \param[in] VAL: a value of SysTick->VAL register.
+    \param[in] val: a value of SysTick->VAL register.
 */
 __stk_attr_unused /* can be unused due to configuration */
-static __stk_forceinline uint32_t HW_SysTickElapsed(uint32_t VAL)
+static __stk_forceinline uint32_t HW_SysTickElapsed(uint32_t val)
 {
-    return SysTick->LOAD - VAL;
+    return SysTick->LOAD - val;
 }
 
 /*! \brief Rearm SysTick timer peripheral with new period.
@@ -893,7 +907,7 @@ static __stk_forceinline void HW_DWTEnableCounter()
 #if defined(DWT)
     // disable counter briefly to safely reset the value to zero
     DWT->CTRL &= ~DWT_CTRL_CYCCNTENA_Msk;
-    DWT->CYCCNT = 0;
+    DWT->CYCCNT = 0U;
 
     // enable
     DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
@@ -917,21 +931,21 @@ static __stk_forceinline uint32_t HW_DWTGetCounter()
 void HW_Configure_SAU()
 {
     // Disable SAU during configuration
-    SAU->CTRL = 0;
+    SAU->CTRL = 0U;
 
     // 1. Define Secure Region (Internal SAU config)
-    SAU->RNR = 0;
-    SAU->RBAR = 0x10000000;
-    SAU->RLAR = (0x101FFFFF) | 1; // Secure Flash (2MB)
+    SAU->RNR = 0U;
+    SAU->RBAR = 0x10000000U;
+    SAU->RLAR = (0x101FFFFFU) | 1U; // Secure Flash (2MB)
 
     // 2. Define NSC Region (Where SG instructions live)
     // Note: The SAU marks this as "Secure, Non-Secure Callable"
-    SAU->RNR = 1;
-    SAU->RBAR = 0x10200000;
-    SAU->RLAR = (0x10200FFF) | (1U << 1) | 1U;  // NSC bit + enable in one write
+    SAU->RNR = 1U;
+    SAU->RBAR = 0x10200000U;
+    SAU->RLAR = (0x10200FFFU) | (1U << 1) | 1U;  // NSC bit + enable in one write
 
     // Enable SAU (All memory not defined here defaults to Secure)
-    SAU->CTRL = 1;
+    SAU->CTRL = 1U;
 }
 #endif
 
@@ -941,7 +955,7 @@ static volatile bool s_StkCortexmCsuLock = false;
 //! Internal context.
 static struct Context final : public PlatformContext
 {
-    Context() : PlatformContext(), m_exit_buf(), m_overrider(nullptr),
+    explicit Context() : PlatformContext(), m_exit_buf(), m_overrider(nullptr),
     #if STK_TICKLESS_IDLE
         m_sleep_ticks(0), m_sleep_error(0U),
     #endif
@@ -951,7 +965,7 @@ static struct Context final : public PlatformContext
     /*! \brief Destructor.
         \note  MISRA deviation: [STK-DEV-005] Rule 10-3-2.
     */
-    ~Context() = default;
+    STK_VIRT_DTOR ~Context() = default;
 
     void Initialize(IPlatform::IEventHandler *handler, IKernelService *service, Stack *exit_trap,
         uint32_t resolution_us) override
@@ -960,14 +974,8 @@ static struct Context final : public PlatformContext
 
         STK_STATIC_ASSERT_DESC_N(SP, offsetof(Stack, SP) == 0U,
             "expect Stack::mode member at offset of 0 (first member)");
-        STK_STATIC_ASSERT_DESC_N(mode, offsetof(Stack, mode) == 4U,
+        STK_STATIC_ASSERT_DESC_N(mode, offsetof(Stack, access_mode) == 4U,
             "expect Stack::mode member at offset of 4 (second member)");        
-    #ifdef __ICCARM__
-        STK_STATIC_ASSERT_DESC_N(AFS, sizeof(std::atomic_flag) == sizeof(bool),
-            "IAR spinlock: atomic_flag size mismatch");
-        STK_STATIC_ASSERT_DESC_N(AFA, alignof(std::atomic_flag) <= alignof(bool),
-            "IAR spinlock: atomic_flag alignment stricter than bool");
-    #endif
 
         m_csu         = 0U;
         m_csu_nesting = 0U;
@@ -1028,7 +1036,9 @@ static struct Context final : public PlatformContext
 
         // rearm SysTick only if tick period changed
         if (ticks != m_sleep_ticks)
+        {
             m_sleep_ticks = ReloadTickPeriod(ticks);
+        }
     #else
         OnTick();
     #endif
@@ -1067,7 +1077,7 @@ static struct Context final : public PlatformContext
         if (m_csu_nesting == 0U)
         {
             // capture the state before releasing lock
-            uint32_t ses_to_restore = m_csu;
+            const uint32_t ses_to_restore = m_csu;
 
             // release global lock
             HW_SpinLockUnlock(s_StkCortexmCsuLock);
@@ -1081,7 +1091,7 @@ static struct Context final : public PlatformContext
     __stk_forceinline void UnprivEnterCriticalSection()
     {
         // elevate to privileged/disabled state via SVC
-        Word current_ses = HW_SVCEnterCritical();
+        const Word current_ses = HW_SVCEnterCritical();
 
         if (m_csu_nesting == 0U)
         {
@@ -1109,7 +1119,7 @@ static struct Context final : public PlatformContext
         if (m_csu_nesting == 0U)
         {
             // capture the state before releasing lock
-            Word ses_to_restore = m_csu;
+            const Word ses_to_restore = m_csu;
 
             // release global lock
             HW_SpinLockUnlock(s_StkCortexmCsuLock);
@@ -1168,6 +1178,11 @@ static struct Context final : public PlatformContext
             HW_EnterSleepMode();
         }
     }
+    
+    uint32_t GetTickResolutionInClockCycles()
+    {
+        return static_cast<uint32_t>(ConvertTimeUsToClockCycles(HW_CoreClockFrequency(), static_cast<Ticks>(m_tick_resolution)));
+    }
 
     void Start();
     void OnStart();
@@ -1200,12 +1215,12 @@ class HiResClockDWT
     uint32_t m_prev;
 
 public:
-    HiResClockDWT() : m_acc(0), m_prev(0U)
+    HiResClockDWT() : m_acc(0U), m_prev(0U)
     {
         HW_DWTEnableCounter();
 
         m_prev = HW_DWTGetCounter();
-        m_acc  = 0;
+        m_acc  = 0U;
     }
 
     static HiResClockDWT *GetInstance()
@@ -1221,7 +1236,7 @@ public:
         const uint32_t current = HW_DWTGetCounter();
 
         // unsigned subtraction handles the wrap-around perfectly
-        uint32_t delta = current - m_prev;
+        const uint32_t delta = current - m_prev;
         m_acc += delta;
 
         m_prev = current;
@@ -1254,10 +1269,10 @@ public:
     Cycles GetCycles()
     {
         // On M0, combine the coarse OS ticks with the fine-grained SysTick counter
-        Cycles cycles = ConvertTimeUsToClockCycles(HW_CoreClockFrequency(), stk::GetTicks() * GetContext().m_tick_resolution);
+        const Cycles cycles = ConvertTimeUsToClockCycles(HW_CoreClockFrequency(), static_cast<Ticks>(stk::GetTicks() * GetContext().m_tick_resolution));
 
-        uint32_t val  = HW_SysTickValue(); // down-counter (cycles remaining in current tick)
-        uint32_t load = SysTick->LOAD;     // current reload value
+        const uint32_t val  = HW_SysTickValue(); // down-counter (cycles remaining in current tick)
+        const uint32_t load = SysTick->LOAD;     // current reload value
 
         // total elapsed cycles
         return cycles + static_cast<Cycles>(load - val);
@@ -1303,23 +1318,25 @@ void PlatformArmCortexM::ProcessTick()
 #if STK_TICKLESS_IDLE
 Timeout Context::ReloadTickPeriod(Timeout ticks_requested)
 {
-    const uint32_t SYSTICK_MAX_LOAD = 0x00FFFFFFu; // SysTick LOAD register is 24-bit
-    const uint32_t reload = static_cast<uint32_t>(ConvertTimeUsToClockCycles(HW_CoreClockFrequency(), m_tick_resolution));
-    if (reload == 0U)
+    const uint32_t SYSTICK_MAX_LOAD = 0x00FFFFFFU; // SysTick LOAD register is 24-bit
+    const uint32_t tick_resolution = GetTickResolutionInClockCycles();
+    if (tick_resolution == 0U)
     {
         STK_ASSERT(false);
         return NO_WAIT;
     }
         
     // guard against uint32_t overflow in the reload calculation
-    STK_ASSERT(static_cast<uint64_t>(ticks_requested) * reload <= UINT32_MAX);
+    STK_ASSERT(static_cast<uint64_t>(ticks_requested) * tick_resolution <= UINT32_MAX);
 
     // clamp ticks_requested so that cpu_ticks_requested fits into 24-bit SysTick LOAD register
     // without clamping large sleep tick counts silently truncate LOAD, causing the timer to fire far too early
     // breaking the timing
-    const Timeout max_ticks = static_cast<Timeout>(SYSTICK_MAX_LOAD / reload);
+    const Timeout max_ticks = static_cast<Timeout>(SYSTICK_MAX_LOAD / tick_resolution);
     if (ticks_requested > max_ticks)
+    {
         ticks_requested = max_ticks;
+    }
 
     // start counting how many CPU cycles further instructions take until SysTick timer is enabled again;
     // without DWT we will have tick error of around 80 cycles depending on CPU model and compiler optimization
@@ -1336,16 +1353,18 @@ Timeout Context::ReloadTickPeriod(Timeout ticks_requested)
     const uint32_t elapsed_till_stop = HW_SysTickElapsed(HW_SysTickValueAfterDisable());
 
     // OnTick() should not consume more than next period
-    STK_ASSERT(static_cast<Timeout>(elapsed_till_stop / reload) <= static_cast<Timeout>(ticks_requested));
+    STK_ASSERT(static_cast<Timeout>(elapsed_till_stop / tick_resolution) <= static_cast<Timeout>(ticks_requested));
 
-    const uint32_t cpu_ticks_requested = static_cast<uint32_t>(ticks_requested) * reload;
+    const uint32_t cpu_ticks_requested = static_cast<uint32_t>(ticks_requested) * tick_resolution;
 
     // substract number of cycles elapsed till SysTick stop + error from previous round
     uint32_t new_load = cpu_ticks_requested - elapsed_till_stop - m_sleep_error;
 
     // clamp: rearm overhead must never push new_load into underflow
     if (new_load > cpu_ticks_requested)
+    {
         new_load = cpu_ticks_requested;
+    }
 
     // reload with elapsed ticks accounted
     HW_SysTickRearm(new_load);
@@ -1371,7 +1390,7 @@ extern "C" void STK_SYSTICK_HANDLER()
 #ifdef HAL_MODULE_ENABLED // STM32 HAL
     // make sure STM32 HAL gets timing information as it depends on SysTick in delaying procedures
 #if STK_TICKLESS_IDLE
-    uwTick += ctx.m_sleep_ticks * ctx.m_tick_resolution;
+    uwTick += static_cast<uint32_t>(ctx.m_sleep_ticks * ctx.m_tick_resolution);
 #else
     HAL_IncTick();
 #endif
@@ -1644,15 +1663,16 @@ void Context::Start()
     m_exiting = false;
 
     // save jump location of the Exit trap
-    SaveJmp(m_exit_buf);
+    STK_UNUSED(SaveJmp(m_exit_buf));
     if (m_exiting)
     {
         // notify kernel about a full stop
         m_handler->OnStop();
-        return;
     }
-
-    HW_StartScheduler();
+    else
+    {
+        HW_StartScheduler();
+    }
 }
 
 void Context::OnStart()
@@ -1685,8 +1705,8 @@ void Context::OnStart()
 #if STK_TICKLESS_IDLE
 Timeout Context::Suspend()
 {
-    const uint32_t resolution = static_cast<uint32_t>(ConvertTimeUsToClockCycles(HW_CoreClockFrequency(), m_tick_resolution));
-    if (resolution == 0U)
+    const uint32_t tick_resolution = GetTickResolutionInClockCycles();
+    if (tick_resolution == 0U)
     {
         STK_ASSERT(false);
         return NO_WAIT;
@@ -1717,8 +1737,8 @@ Timeout Context::Suspend()
 
     // get already elapsed ticks since the OnTick and a call to Suspend(), we shall account for this
     // period and return only the remainder
-    Timeout elapsed_ticks = static_cast<Timeout>(elapsed / resolution);
-    Timeout sleep_ticks = Max(m_sleep_ticks - elapsed_ticks, static_cast<Timeout>(0));
+    const Timeout elapsed_ticks = static_cast<Timeout>(elapsed / tick_resolution);
+    const Timeout sleep_ticks = Max(m_sleep_ticks - elapsed_ticks, static_cast<Timeout>(0));
 
     HW_EnableInterrupts();
 
@@ -1751,36 +1771,33 @@ extern "C" __stk_attr_used void SVC_Handler_Main(Word *svc_args)
 
     // priority 0 (NMI, HardFault) unaffected: SVC (priority 0 per OnStart()) remains
     // reachable so SVC_EXIT_CRITICAL can always unwind
-    STK_STATIC_ASSERT_DESC_N(NVIC, __NVIC_PRIO_BITS < 32u,
+    STK_STATIC_ASSERT_DESC_N(NVIC, __NVIC_PRIO_BITS < 32U,
         "NVIC priority bit width exceeds safe shift range");
 
     // 'volatile': R0 is written back to stacked memory, compiler must not eliminate the store
-    volatile ExceptionFrame * const frame = reinterpret_cast<volatile ExceptionFrame *>(svc_args);
+    volatile ExceptionFrame *const frame = reinterpret_cast<volatile ExceptionFrame *>(svc_args);
 
     // details: https://developer.arm.com/documentation/ka004005/latest
     // Thumb SVC encoding: [15:8] = 0xDF, [7:0] = imm8
-    // ---
     // opcode lives two bytes (one Thumb halfword) before the stacked PC:
-    // do explicit subtraction instead of negative indexing (MISRA C++ 5-0-16),
-    // uint8_t extracted before ESvcCommandId cast to avoid impl-defined enum conversion (MISRA 5-2-6)
-    const uint8_t       *insn_ptr = hw::WordToPtr<const uint8_t>(frame->PC) - 2;
-    const ESvcCommandId  command  = static_cast<ESvcCommandId>(*insn_ptr);
+    const uint8_t       *const insn_ptr = hw::WordToPtr<const uint8_t>(frame->PC - 2U);
+    const ESvcCommandId  command        = static_cast<ESvcCommandId>(*insn_ptr);
 
     switch (command)
     {
     case SVC_START_SCHEDULING: {
         // disallow any duplicate attempt
         STK_ASSERT(!GetContext().m_started);
-        if (GetContext().m_started)
-            return;
+        if (!GetContext().m_started)
+        {
+            // make sure interrupts do not interfere, OnStart expects interrupts disabled
+            HW_DisableInterrupts();
 
-        // make sure interrupts do not interfere, OnStart expects interrupts disabled
-        HW_DisableInterrupts();
+            GetContext().OnStart();
 
-        GetContext().OnStart();
-
-        // start first task
-        OnTaskStart();
+            // start first task
+            OnTaskStart();
+        }
         break; }
 
     /*case SVC_FORCE_SWITCH: {
@@ -1907,9 +1924,9 @@ extern "C" __stk_attr_naked void STK_SVC_HANDLER()
     );
 }
 
-static void OnTaskRun(ITask *task)
+static void OnTaskRun(ITask *runnable)
 {
-    task->Run();
+    runnable->Run();
 }
 
 static void OnTaskExit()
@@ -2001,16 +2018,16 @@ bool PlatformArmCortexM::InitStack(EStackType stack_type, Stack *stack, IStackMe
     STK_ASSERT(stack_memory->GetStackSize() > STK_CORTEX_M_TOTAL_REGISTER_COUNT);
 
     // initialize stack memory
-    Word *stack_top = Context::InitStackMemory(stack_memory);
+    const Word stack_top = Context::InitStackMemory(stack_memory);
 
     // initialize Stack Pointer (SP)
-    stack->SP = hw::PtrToWord(stack_top - STK_CORTEX_M_TOTAL_REGISTER_COUNT);
+    stack->SP = stack_top - (STK_CORTEX_M_TOTAL_REGISTER_COUNT * sizeof(Word));
 
     // place the initial task frame flush against the top of the stack:
     // TaskFrame::exc (ExceptionFrame) occupies the top 8 words, TaskFrame::EXC_RETURN
     // (when present) sits immediately below it, and TrustZoneFrame (when present) sits
     // below that.
-    TaskFrame * const task_frame = reinterpret_cast<TaskFrame *>(stack_top) - 1;
+    TaskFrame *const task_frame = hw::WordToPtr<TaskFrame>(stack_top - sizeof(TaskFrame));
 
     // initialize registers for the user task's first start
     switch (stack_type)
@@ -2033,8 +2050,9 @@ bool PlatformArmCortexM::InitStack(EStackType stack_type, Stack *stack, IStackMe
         task_frame->exc.R0 = 0U;
         break; }
 
-    default:
-        return false;
+    default: {
+        STK_KERNEL_PANIC(KERNEL_PANIC_BAD_STACK_TYPE);
+        break; }
     }
 
     // details: "Program counter: Bit [0] is always 0, so instructions are always aligned to halfword boundaries",
@@ -2059,7 +2077,7 @@ bool PlatformArmCortexM::InitStack(EStackType stack_type, Stack *stack, IStackMe
     // Reference: ARMv8-M Architecture Reference Manual B1.5.8.
     //
 #if defined(_STK_CORTEX_M_TRUSTZONE) && (__CORTEX_M >= 33U)
-    if ((stack_type == STACK_USER_TASK) && (stack->mode == ACCESS_PRIVILEGED))
+    if ((stack_type == STACK_USER_TASK) && (stack->access_mode == ACCESS_PRIVILEGED))
         task_frame->EXC_RETURN = STK_CORTEX_M_EXC_RETURN_S_THREAD_PSP;
     else
         task_frame->EXC_RETURN = STK_CORTEX_M_EXC_RETURN_NS_THREAD_PSP;
@@ -2266,22 +2284,34 @@ IWaitObject *PlatformArmCortexM::Wait(ISyncObject *sync_obj, IMutex *mutex, Time
 
 TId PlatformArmCortexM::GetTid() const
 {
-    Word isr = HW_GetCurrentException();
+    TId result;
+    const Word isr = HW_GetCurrentException();
 
     // return special TId which denotes ISR
     if (isr != 0U)
     {
-        TId isr_tid = TID_ISR_N | isr;
+        const TId isr_tid = TID_ISR_N | isr;
         STK_ASSERT(IsIsrTid(isr_tid));
-        return isr_tid;
+        result = isr_tid;
     }
-
-    return GetContext().m_handler->OnGetTid(HW_GetCallerSP());
+    else
+    {
+        result = GetContext().m_handler->OnGetTid(HW_GetCallerSP());
+    }
+    
+    return result;
 }
 
 void PlatformArmCortexM::ProcessHardFault()
 {
-    if ((GetContext().m_overrider == nullptr) || !GetContext().m_overrider->OnHardFault())
+    bool is_handled = false;
+
+    if (GetContext().m_overrider != nullptr)
+    {
+        is_handled = GetContext().m_overrider->OnHardFault();
+    }
+
+    if (!is_handled)
     {
         STK_KERNEL_PANIC(KERNEL_PANIC_HRT_HARD_FAULT);
     }
@@ -2323,20 +2353,58 @@ IKernelService *IKernelService::GetInstance()
 
 void stk::hw::CriticalSection::Enter()
 {
+    bool is_privileged = false;
+  
     // if we are in Handler or Privileged Thread Mode, we can skip the SVC and take the fast path
-    if (HW_IsHandlerMode() || HW_IsPrivilegedThreadMode())
-        GetContext().EnterCriticalSection();
+    if (HW_IsPrivilegedThreadMode())
+    {
+        is_privileged = true;
+    }
+    else if (HW_IsHandlerMode())
+    {
+        is_privileged = true;
+    }
     else
+    {
+        // not privileged path
+    }
+
+    if (is_privileged)
+    {
+        GetContext().EnterCriticalSection();
+    }
+    else
+    {
         GetContext().UnprivEnterCriticalSection();
+    }
 }
 
 void stk::hw::CriticalSection::Exit()
 {
+    bool is_privileged = false;
+  
     // if we are in Handler or Privileged Thread Mode, we can skip the SVC and take the fast path
-    if (HW_IsHandlerMode() || HW_IsPrivilegedThreadMode())
-        GetContext().ExitCriticalSection();
+    if (HW_IsPrivilegedThreadMode())
+    {
+        is_privileged = true;
+    }
+    else if (HW_IsHandlerMode())
+    {
+        is_privileged = true;
+    }
     else
+    {
+        // not privileged path
+    }
+
+    if (is_privileged)
+    {
+        GetContext().ExitCriticalSection();
+    }
+    else
+    {
         GetContext().UnprivExitCriticalSection();
+    }
 }
 
 void stk::hw::SpinLock::Lock()
@@ -2366,8 +2434,8 @@ Cycles stk::hw::HiResClock::GetCycles()
 
 uint32_t stk::hw::HiResClock::GetFrequency()
 {
-    Cycles freq = HiResClockImpl::GetInstance()->GetFrequency();
-    STK_ASSERT(freq != 0);
+    const uint32_t freq = HiResClockImpl::GetInstance()->GetFrequency();
+    STK_ASSERT(freq != 0U);
     return freq;
 }
 

--- a/stk/src/arch/risc-v/stk_arch_risc-v.cpp
+++ b/stk/src/arch/risc-v/stk_arch_risc-v.cpp
@@ -107,7 +107,7 @@ using namespace stk;
             Defaults to 1.
 */
 #ifndef STK_RISCV_CLINT_MTIMECMP_PER_HART
-    #define STK_RISCV_CLINT_MTIMECMP_PER_HART (1)
+    #define STK_RISCV_CLINT_MTIMECMP_PER_HART 1
 #endif
 
 /*! \brief  Get the hardware thread id (hart) of the calling core.
@@ -155,44 +155,44 @@ using namespace stk;
 
 
 #if (__riscv_32e == 1)
-    #define STK_RISCV_REGISTER_COUNT (15 + (STK_RISCV_FPU != 0 ? 31 : 0))
+    #define STK_RISCV_REGISTER_COUNT (15U + (STK_RISCV_FPU != 0U ? 31U : 0U))
 #else
-    #define STK_RISCV_REGISTER_COUNT (31 + (STK_RISCV_FPU != 0 ? 31 : 0))
+    #define STK_RISCV_REGISTER_COUNT (31U + (STK_RISCV_FPU != 0U ? 31U : 0U))
 #endif
 
-#define STK_SERVICE_SLOTS 2 // (0) mepc, (1) mstatus
+#define STK_SERVICE_SLOTS 2U // (0) mepc, (1) mstatus
 
 #if (__riscv_32e == 1)
     #define FOFFSET XSTR(68) // FP stack offset = (17 * 4)
     #if (STK_RISCV_FPU == 0)
-        #define REGSIZE XSTR(((15 + STK_SERVICE_SLOTS) * 4)) // STK_RISCV_REGISTER_COUNT + 2 for mepc, mstatus
+        #define REGSIZE XSTR(((15U + STK_SERVICE_SLOTS) * 4U)) // STK_RISCV_REGISTER_COUNT + 2 for mepc, mstatus
     #else
         #if (STK_RISCV_FPU == 32)
-        #define REGSIZE XSTR((((15 + STK_SERVICE_SLOTS) * 4) + (31 * 4))) // STK_RISCV_REGISTER_COUNT + 2 for mepc, mstatus + 32 fp registers
+        #define REGSIZE XSTR((((15U + STK_SERVICE_SLOTS) * 4U) + (31U * 4U))) // STK_RISCV_REGISTER_COUNT + 2 for mepc, mstatus + 32 fp registers
         #elif (STK_RISCV_FPU == 64)
-        #define REGSIZE XSTR((((15 + STK_SERVICE_SLOTS) * 4) + (31 * 8))) // STK_RISCV_REGISTER_COUNT + 2 for mepc, mstatus + 32 fp registers
+        #define REGSIZE XSTR((((15U + STK_SERVICE_SLOTS) * 4U) + (31U * 8U))) // STK_RISCV_REGISTER_COUNT + 2 for mepc, mstatus + 32 fp registers
         #endif
     #endif
 #elif (__riscv_xlen == 32)
     #define FOFFSET XSTR(132) // FP stack offset = (33 * 4)
     #if (STK_RISCV_FPU == 0)
-        #define REGSIZE XSTR(((31 + STK_SERVICE_SLOTS) * 4)) // STK_RISCV_REGISTER_COUNT + 2 for mepc, mstatus
+        #define REGSIZE XSTR(((31U + STK_SERVICE_SLOTS) * 4U)) // STK_RISCV_REGISTER_COUNT + 2 for mepc, mstatus
     #else
         #if (STK_RISCV_FPU == 32)
-        #define REGSIZE XSTR((((31 + STK_SERVICE_SLOTS) * 4) + (31 * 4))) // STK_RISCV_REGISTER_COUNT + 2 for mepc, mstatus + 32 fp registers
+        #define REGSIZE XSTR((((31U + STK_SERVICE_SLOTS) * 4U) + (31U * 4U))) // STK_RISCV_REGISTER_COUNT + 2 for mepc, mstatus + 32 fp registers
         #elif (STK_RISCV_FPU == 64)
-        #define REGSIZE XSTR((((31 + STK_SERVICE_SLOTS) * 4) + (31 * 8))) // STK_RISCV_REGISTER_COUNT + 2 for mepc, mstatus + 32 fp registers
+        #define REGSIZE XSTR((((31U + STK_SERVICE_SLOTS) * 4U) + (31U * 8U))) // STK_RISCV_REGISTER_COUNT + 2 for mepc, mstatus + 32 fp registers
         #endif
     #endif
 #elif (__riscv_xlen == 64)
     #define FOFFSET XSTR(264) // FP stack offset = (33 * 8)
     #if (STK_RISCV_FPU == 0)
-        #define REGSIZE XSTR(((31 + STK_SERVICE_SLOTS) * 8)) // STK_RISCV_REGISTER_COUNT + 2 for mepc, mstatus
+        #define REGSIZE XSTR(((31U + STK_SERVICE_SLOTS) * 8U)) // STK_RISCV_REGISTER_COUNT + 2 for mepc, mstatus
     #else
         #if (STK_RISCV_FPU == 32)
-        #define REGSIZE XSTR((((31 + STK_SERVICE_SLOTS) * 8) + (31 * 4))) // STK_RISCV_REGISTER_COUNT + 2 for mepc, mstatus + 32 fp registers
+        #define REGSIZE XSTR((((31U + STK_SERVICE_SLOTS) * 8U) + (31U * 4U))) // STK_RISCV_REGISTER_COUNT + 2 for mepc, mstatus + 32 fp registers
         #elif (STK_RISCV_FPU == 64)
-        #define REGSIZE XSTR((((31 + STK_SERVICE_SLOTS) * 8) + (31 * 8))) // STK_RISCV_REGISTER_COUNT + 2 for mepc, mstatus + 32 fp registers
+        #define REGSIZE XSTR((((31U + STK_SERVICE_SLOTS) * 8U) + (31U * 8U))) // STK_RISCV_REGISTER_COUNT + 2 for mepc, mstatus + 32 fp registers
         #endif
     #endif
 #endif
@@ -439,10 +439,11 @@ static __stk_forceinline uint32_t HW_MtimeClockFrequency()
 static __stk_forceinline uint64_t HW_GetMtime()
 {
 #if ( __riscv_xlen > 32)
-    return *((volatile uint64_t *)STK_RISCV_CLINT_MTIME_ADDR);
+    return *(hw::WordToPtr<volatile uint64_t>(STK_RISCV_CLINT_MTIME_ADDR));
 #else
-    volatile uint32_t *mtime_hi = ((uint32_t *)STK_RISCV_CLINT_MTIME_ADDR) + 1;
-    volatile uint32_t *mtime_lo = ((uint32_t *)STK_RISCV_CLINT_MTIME_ADDR);
+    const Word mtime_base = STK_RISCV_CLINT_MTIME_ADDR;
+    const volatile uint32_t *const mtime_lo = hw::WordToPtr<volatile uint32_t>(mtime_base);
+    const volatile uint32_t *const mtime_hi = hw::WordToPtr<volatile uint32_t>(mtime_base + sizeof(uint32_t));
 
     uint32_t hi, lo;
     do
@@ -452,7 +453,7 @@ static __stk_forceinline uint64_t HW_GetMtime()
     }
     while (hi != (*mtime_hi)); // make sure mtime_hi did not tick when read mtime_lo
 
-    return ((uint64_t)hi << 32) | lo;
+    return (static_cast<uint64_t>(hi) << 32) | lo;
 #endif
 }
 
@@ -464,25 +465,26 @@ static __stk_forceinline void HW_SetMtimecmp(uint64_t time_next)
 #if STK_RISCV_CLINT_MTIMECMP_PER_HART
     const uint8_t hart = HW_GetHartId();
 #else
-    const uint8_t hart = 0;
+    const uint8_t hart = 0U;
 #endif
 
 #if (__riscv_xlen == 64)
-    ((volatile uint64_t *)STK_RISCV_CLINT_MTIMECMP_ADDR)[hart] = next;
+    hw::WordToPtr<volatile uint64_t>(STK_RISCV_CLINT_MTIMECMP_ADDR)[hart] = next;
 #else
-    volatile uint32_t *mtime_lo = (uint32_t *)((uint64_t *)STK_RISCV_CLINT_MTIMECMP_ADDR + hart);
-    volatile uint32_t *mtime_hi = mtime_lo + 1;
+    const Word mtimecmp_base = STK_RISCV_CLINT_MTIMECMP_ADDR + (hart * sizeof(uint64_t));
+    volatile uint32_t *mtimecmp_lo = hw::WordToPtr<volatile uint32_t>(mtimecmp_base);
+    volatile uint32_t *mtimecmp_hi = hw::WordToPtr<volatile uint32_t>(mtimecmp_base + sizeof(uint32_t));
 
     // expecting 4-byte aligned memory
-    STK_ASSERT(((uintptr_t)mtime_lo & (4 - 1)) == 0);
-    STK_ASSERT(((uintptr_t)mtime_hi & (4 - 1)) == 0);
+    STK_ASSERT(((uintptr_t)mtimecmp_lo & (4U - 1U)) == 0U);
+    STK_ASSERT(((uintptr_t)mtimecmp_hi & (4U - 1U)) == 0U);
 
     // prevent unexpected interrupt by setting some very large value to the high part
     // details: https://riscv.org/wp-content/uploads/2017/05/riscv-privileged-v1.10.pdf, page 31
-    (*mtime_hi) = ~0;
+    (*mtimecmp_hi) = ~0U;
 
-    (*mtime_lo) = (uint32_t)(time_next & 0xFFFFFFFF);
-    (*mtime_hi) = (uint32_t)(time_next >> 32);
+    (*mtimecmp_lo) = (uint32_t)(time_next & 0xFFFFFFFFU);
+    (*mtimecmp_hi) = (uint32_t)(time_next >> 32);
 #endif
 }
 
@@ -594,10 +596,10 @@ static __stk_forceinline bool HW_SpinLockTryLock(volatile bool &lock)
 */
 static __stk_forceinline void HW_SpinLockLock(volatile bool &lock)
 {
-    uint32_t timeout = 0xFFFFFF;
+    uint32_t timeout = 0xFFFFFFU;
     while (!HW_SpinLockTryLock(lock))
     {
-        if (--timeout == 0)
+        if (--timeout == 0U)
         {
             // Invariant violated: the lock owner exited without releasing,
             // Kernel state is suspect, enter defined safe state.
@@ -643,7 +645,7 @@ static __stk_forceinline void HW_ScheduleContextSwitch(uint8_t hart)
 #ifdef _STK_RISCV_USE_PENDSV
     // Pend Machine Software Interrupt (MSI) - equivalent of ARM's PENDSVSET
     volatile uint32_t *msip = (volatile uint32_t *)(STK_RISCV_CLINT_BASE_ADDR);
-    msip[hart] = 1; // set pending
+    msip[hart] = 1U; // set pending
     __DSB();
 #else
     (void)hart;
@@ -671,7 +673,7 @@ static volatile bool s_StkRiscvCsuLock = false;
             read by STK_MSI_HANDLER.
 */
 #ifdef _STK_RISCV_USE_PENDSV
-Stack * volatile s_StkRiscvStackIdle[STK_ARCH_CPU_COUNT] = {};
+Stack *volatile s_StkRiscvStackIdle[STK_ARCH_CPU_COUNT] = {};
 
 /*! \brief  Scratch storage for the SP of the task interrupted by STK_SYSTICK_HANDLER, per hart.
     \note   Written and read exclusively by STK_SYSTICK_HANDLER. Never touched by
@@ -684,12 +686,12 @@ volatile Word s_StkRiscvSpIsrInt[STK_ARCH_CPU_COUNT] = {};
 /*! \brief  Pointer to the active task stack, per hart. Written by scheduler,
             read by STK_MSI_HANDLER (PendSV) or STK_SYSTICK_HANDLER (non-PendSV).
 */
-Stack * volatile s_StkRiscvStackActive[STK_ARCH_CPU_COUNT] = {};
+Stack *volatile s_StkRiscvStackActive[STK_ARCH_CPU_COUNT] = {};
 
 /*! \brief  Pointer to the private ISR stack, per hart. Written once by
             Context::OnStart, read by both ISR handlers.
 */
-Stack * volatile s_StkRiscvStackIsr[STK_ARCH_CPU_COUNT] = {};
+Stack *volatile s_StkRiscvStackIsr[STK_ARCH_CPU_COUNT] = {};
 
 //! ----------------------------------------------------------------------------
 
@@ -884,7 +886,7 @@ typedef HiResClockMTIME HiResClockImpl;
 //! Internal context.
 static struct Context final : public PlatformContext
 {
-    Context() : PlatformContext(), m_stack_main(), m_stack_isr(), m_stack_isr_mem(),
+    explicit Context() : PlatformContext(), m_stack_main(), m_stack_isr(), m_stack_isr_mem(),
         m_exit_buf(), m_overrider(nullptr), m_specific(nullptr), m_tick_period(0), m_last_mtime(0ULL),
     #if STK_TICKLESS_IDLE
         m_sleep_ticks(0),
@@ -897,8 +899,7 @@ static struct Context final : public PlatformContext
     /*! \brief Destructor.
         \note  MISRA deviation: [STK-DEV-005] Rule 10-3-2.
     */
-    ~Context()
-    {}
+    STK_VIRT_DTOR ~Context() = default;
 
     void Initialize(IPlatform::IEventHandler *handler, IKernelService *service, Stack *exit_trap,
         uint32_t resolution_us) override
@@ -908,18 +909,18 @@ static struct Context final : public PlatformContext
         // init ISR's stack
         {
             StackMemoryWrapper<STK_RISCV_ISR_STACK_SIZE> stack_isr_mem(&m_stack_isr_mem);
-            m_stack_isr.SP   = hw::PtrToWord(InitStackMemory(&stack_isr_mem));
-            m_stack_isr.mode = ACCESS_PRIVILEGED;
+            m_stack_isr.SP          = InitStackMemory(&stack_isr_mem);
+            m_stack_isr.access_mode = ACCESS_PRIVILEGED;
         }
 
         // init Main stack
         {
-            m_stack_main.SP   = STK_STACK_MEMORY_FILLER;
-            m_stack_main.mode = ACCESS_PRIVILEGED;
+            m_stack_main.SP          = STK_STACK_MEMORY_FILLER;
+            m_stack_main.access_mode = ACCESS_PRIVILEGED;
         }
 
-        m_csu         = 0;
-        m_csu_nesting = 0;
+        m_csu         = 0U;
+        m_csu_nesting = 0U;
         m_tick_period = ConvertTimeUsToClockCycles(STK_TIMER_CLOCK_FREQUENCY, resolution_us);
         m_last_mtime  = 0ULL;
         m_starting    = false;
@@ -976,7 +977,7 @@ static struct Context final : public PlatformContext
         Word current_ses;
         HW_CriticalSectionStart(current_ses);
 
-        if (m_csu_nesting == 0)
+        if (m_csu_nesting == 0U)
         {
             // ONLY attempt the global spinlock if we aren't already nested
             HW_SpinLockLock(s_StkRiscvCsuLock);
@@ -995,13 +996,13 @@ static struct Context final : public PlatformContext
 
     __stk_forceinline void ExitCriticalSection()
     {
-        STK_ASSERT(m_csu_nesting != 0);
+        STK_ASSERT(m_csu_nesting != 0U);
         --m_csu_nesting;
 
-        if (m_csu_nesting == 0)
+        if (m_csu_nesting == 0U)
         {
             // capture the state before releasing lock
-            Word ses_to_restore = m_csu;
+            const Word ses_to_restore = m_csu;
 
             // release global lock
             HW_SpinLockUnlock(s_StkRiscvCsuLock);
@@ -1014,16 +1015,16 @@ static struct Context final : public PlatformContext
     uint64_t GetSleepTicksPrev()
     {
     #if STK_TICKLESS_IDLE
-        uint64_t ticks = (static_cast<uint64_t>(m_sleep_ticks) * static_cast<uint64_t>(m_tick_period));
+        const uint64_t ticks = (static_cast<uint64_t>(m_sleep_ticks) * static_cast<uint64_t>(m_tick_period));
     #else
-        uint64_t ticks = (1U * static_cast<uint64_t>(m_tick_period));
+        const uint64_t ticks = (1U * static_cast<uint64_t>(m_tick_period));
     #endif
         return ticks;
     }
 
     uint64_t GetTimeNow(uint64_t &error)
     {
-        uint64_t mtime_now = HW_GetMtime();
+        const uint64_t mtime_now = HW_GetMtime();
         error = (mtime_now - m_last_mtime) - GetSleepTicksPrev();
         return mtime_now;
     }
@@ -1046,8 +1047,8 @@ static struct Context final : public PlatformContext
         // capture mtime at ISR entry as the absolute base for the next period;
         // this eliminates drift from time spent inside OnTick regardless of how
         // long the scheduler takes to run
-        uint64_t error = 0;
-        uint64_t mtime_now = GetTimeNow(error);
+        uint64_t error = 0U;
+        const uint64_t mtime_now = GetTimeNow(error);
         __stk_compiler_barrier(); // avoid compiler reordering, we count ticks from this point
 
         // make sure timer is enabled by the Kernel::Start(), disable its start anywhere else
@@ -1429,12 +1430,12 @@ static __stk_forceinline Word HW_GetCurrentException()
 
 static __stk_forceinline bool HW_IsHandlerMode()
 {
-    Word current_sp = HW_GetCallerSP();
+    const Word current_sp = HW_GetCallerSP();
 
     // get the bounds of the ISR stack from our Context
     // note: STK uses StackMemoryWrapper, so we check against that memory block
-    const Word isr_stack_base = (Word)&GetContext().m_stack_isr_mem;
-    const Word isr_stack_top  = isr_stack_base + STK_RISCV_ISR_STACK_SIZE;
+    const Word isr_stack_base = hw::PtrToWord(&GetContext().m_stack_isr_mem);
+    const Word isr_stack_top  = isr_stack_base + (STK_RISCV_ISR_STACK_SIZE * sizeof(Word));
 
     return ((current_sp >= isr_stack_base) && (current_sp < isr_stack_top));
 }
@@ -1713,7 +1714,7 @@ void Context::OnStart()
 
 STK_RISCV_ISR void STK_SVC_HANDLER()
 {
-    Word cause = HW_GetCurrentException();
+    const Word cause = HW_GetCurrentException();
 
     /*if (cause & (1UL << (__riscv_xlen - 1)))
     {
@@ -1841,22 +1842,27 @@ void Context::Start()
     {
         // notify kernel about a full stop
         m_handler->OnStop();
-        return;
     }
+    else
+    {
+        // enable FPU (if available)
+        HW_EnableFullFpuAccess();
 
-    // enable FPU (if available)
-    HW_EnableFullFpuAccess();
-
-    // start
-    m_starting = true;
-    HW_StartScheduler();
+        // start
+        m_starting = true;
+        HW_StartScheduler();
+    }
 }
 
 #if STK_TICKLESS_IDLE
 Timeout Context::Suspend()
 {
     const uint32_t resolution = static_cast<uint32_t>(ConvertTimeUsToClockCycles(HW_CoreClockFrequency(), m_tick_resolution));
-    STK_ASSERT(resolution != 0);
+    if (resolution == 0U)
+    {
+        STK_ASSERT(false);
+        return NO_WAIT;
+    }
 
     HW_DisableInterrupts();
 
@@ -1872,8 +1878,8 @@ Timeout Context::Suspend()
 
     // get already elapsed ticks since the OnTick and a call to Suspend(), we shall account for this
     // period and return only the remainder
-    Timeout elapsed_ticks = static_cast<Timeout>(elapsed / resolution);
-    Timeout sleep_ticks = Max(m_sleep_ticks - elapsed_ticks, static_cast<Timeout>(0));
+    const Timeout elapsed_ticks = static_cast<Timeout>(elapsed / resolution);
+    const Timeout sleep_ticks = Max(m_sleep_ticks - elapsed_ticks, static_cast<Timeout>(0));
 
     // notify core
     m_handler->OnSuspend(true);
@@ -1913,13 +1919,13 @@ bool PlatformRiscV::InitStack(EStackType stack_type, Stack *stack, IStackMemory 
     STK_ASSERT(stack_memory->GetStackSize() > (STK_RISCV_REGISTER_COUNT + STK_SERVICE_SLOTS));
 
     // initialize stack memory (fills all slots with STK_STACK_MEMORY_FILLER)
-    Word *stack_top = PlatformContext::InitStackMemory(stack_memory);
+    const Word stack_top = PlatformContext::InitStackMemory(stack_memory);
 
     // initialize Stack Pointer (SP): frame sits at the bottom of the register window
-    stack->SP = hw::PtrToWord(stack_top - (STK_RISCV_REGISTER_COUNT + STK_SERVICE_SLOTS));
+    stack->SP = stack_top - ((STK_RISCV_REGISTER_COUNT + STK_SERVICE_SLOTS) * sizeof(Word));
 
     // place the task frame at SP directly at the base of the register window
-    TaskFrame * const task_frame = reinterpret_cast<TaskFrame *>(stack->SP);
+    TaskFrame *const task_frame = hw::WordToPtr<TaskFrame>(stack->SP);
 
     // initialize registers for the user task's first start
     switch (stack_type)
@@ -1940,16 +1946,17 @@ bool PlatformRiscV::InitStack(EStackType stack_type, Stack *stack, IStackMemory 
         task_frame->X1_RA = STK_STACK_MEMORY_FILLER; // should not attempt to exit
         break; }
 
-    default:
-        return false;
+    default: {
+        STK_KERNEL_PANIC(KERNEL_PANIC_BAD_STACK_TYPE);
+        break; }
     }
 
     // mstatus: return to M-mode (MPP), interrupts enabled on mret (MPIE),
     // FPU/extension state initial (FS/XS) if FPU present
-    task_frame->MSTATUS = MSTATUS_MPP | MSTATUS_MPIE | (STK_RISCV_FPU != 0 ? (MSTATUS_FS | MSTATUS_XS) : 0);
+    task_frame->MSTATUS = MSTATUS_MPP | MSTATUS_MPIE | (STK_RISCV_FPU != 0U ? (MSTATUS_FS | MSTATUS_XS) : 0U);
 
 #if (STK_RISCV_FPU != 0)
-    task_frame->X3_FSR = 0; // FCSR = 0: round-to-nearest, no accrued exception flags
+    task_frame->X3_FSR = 0U; // FCSR = 0: round-to-nearest, no accrued exception flags
 #endif
 
     return true;
@@ -2017,26 +2024,30 @@ IWaitObject *PlatformRiscV::Wait(ISyncObject *sync_obj, IMutex *mutex, Timeout t
 
 TId PlatformRiscV::GetTid() const
 {
+    TId result;
+  
     if (HW_IsHandlerMode())
     {
         // to avoid the collision with TID_ISR_N mask, extract and fit into available space:
 
         const Word exc = HW_GetCurrentException();
-
-        Word num = (exc & 0x7FFU);
-
+        const Word num = (exc & 0x7FFU);
     #if (__riscv_xlen > 32)
-        Word interrupt_bit = ((exc & (1ULL << (__riscv_xlen - 1))) ? 0x800U : 0);
+        const Word interrupt_bit = ((exc & (1ULL << (__riscv_xlen - 1))) ? 0x800U : 0);
     #else
-        Word interrupt_bit = ((exc & (1U << (__riscv_xlen - 1))) ? 0x800U : 0);
+        const Word interrupt_bit = ((exc & (1U << (__riscv_xlen - 1))) ? 0x800U : 0);
     #endif
 
-        TId isr_tid = TID_ISR_N | num | interrupt_bit;
+        const TId isr_tid = TID_ISR_N | num | interrupt_bit;
         STK_ASSERT(IsIsrTid(isr_tid));
-        return isr_tid;
+        result = isr_tid;
     }
-
-    return GetContext().m_handler->OnGetTid(HW_GetCallerSP());
+    else
+    {
+        result = GetContext().m_handler->OnGetTid(HW_GetCallerSP());
+    }
+    
+    return result;
 }
 
 Timeout PlatformRiscV::Suspend()
@@ -2059,7 +2070,14 @@ void PlatformRiscV::Resume(Timeout elapsed_ticks)
 
 void PlatformRiscV::ProcessHardFault()
 {
-    if ((GetContext().m_overrider == nullptr) || !GetContext().m_overrider->OnHardFault())
+    bool is_handled = false;
+
+    if (GetContext().m_overrider != nullptr)
+    {
+        is_handled = GetContext().m_overrider->OnHardFault();
+    }
+
+    if (!is_handled)
     {
         STK_KERNEL_PANIC(KERNEL_PANIC_HRT_HARD_FAULT);
     }
@@ -2124,8 +2142,8 @@ Cycles stk::hw::HiResClock::GetCycles()
 
 uint32_t stk::hw::HiResClock::GetFrequency()
 {
-    uint32_t freq = HiResClockImpl::GetInstance()->GetFrequency();
-    STK_ASSERT(freq != 0);
+    const uint32_t freq = HiResClockImpl::GetInstance()->GetFrequency();
+    STK_ASSERT(freq != 0U);
     return freq;
 }
 

--- a/stk/src/arch/x86/win32/stk_arch_x86-win32.cpp
+++ b/stk/src/arch/x86/win32/stk_arch_x86-win32.cpp
@@ -192,10 +192,7 @@ static struct Context final : public PlatformContext
         LoadWindowsAPI();
     }
 
-    /*! \brief Destructor.
-        \note  MISRA deviation: [STK-DEV-005] Rule 10-3-2.
-    */
-    ~Context()
+    virtual ~Context()
     {
     #if STK_TLS
         if (m_tls != TLS_OUT_OF_INDEXES)
@@ -245,7 +242,7 @@ static struct Context final : public PlatformContext
         void InitThread()
         {
             // simulate stack size limitation
-            size_t stack_size = m_task->GetStackSize() * sizeof(Word);
+            const size_t stack_size = m_task->GetStackSize() * sizeof(Word);
 
             m_thread = CreateThread(nullptr, stack_size, &OnTaskRun, this, CREATE_SUSPENDED, &m_thread_id);
         }
@@ -297,7 +294,9 @@ static struct Context final : public PlatformContext
         {
             // avoid suspending self
             if (GetCurrentThreadId() != m_timer_tid)
+            {
                 SuspendThread(m_timer_thread);
+            }
         }
 
         // increase nesting count within a limit
@@ -318,7 +317,9 @@ static struct Context final : public PlatformContext
         {
             // suspending self is not supported
             if (GetCurrentThreadId() != m_timer_tid)
+            {
                 ResumeThread(m_timer_thread);
+            }
         }
 
         STK_X86_WIN32_CRITICAL_SECTION_END(&m_cs);
@@ -359,9 +360,9 @@ void STK_PANIC_HANDLER_DEFAULT(EKernelPanicId id)
     }
 }
 
-static __stk_forceinline DWORD TicksToMs(uint32_t ticks)
+static __stk_forceinline DWORD TicksToMs(uint64_t ticks)
 {
-    return (ticks * GetContext().m_tick_resolution) / 1000U;
+    return static_cast<DWORD>((ticks * GetContext().m_tick_resolution) / 1000U);
 }
 
 static DWORD WINAPI TimerThread(LPVOID param)
@@ -374,7 +375,9 @@ static DWORD WINAPI TimerThread(LPVOID param)
     while (WaitForSingleObject(GetContext().m_timer_thread, wait_ms) == WAIT_TIMEOUT)
     {
         if (GetContext().m_stop_signal)
+        {
             break;
+        }
 
         GetContext().ProcessTick();
 
@@ -390,7 +393,9 @@ void Context::ConfigureTime()
 {
     // Windows timers are jittery, so make resolution more coarse
     if (m_tick_resolution < STK_X86_WIN32_MIN_RESOLUTION)
+    {
         m_tick_resolution = STK_X86_WIN32_MIN_RESOLUTION;
+    }
 
     // increase precision of ticks to at least 1 ms (although Windows timers will still be quite coarse and have jitter of +1 ms)
     timeBeginPeriod(1);
@@ -448,7 +453,9 @@ void Context::CreateTimerThreadAndJoin()
                 STK_ASSERT(exiting_task != nullptr);
 
                 if (exiting_task != nullptr)
+                {
                     m_handler->OnTaskExit(exiting_task->m_stack);
+                }
 
                 m_task_threads.erase(itr);
                 break;
@@ -461,7 +468,9 @@ void Context::CreateTimerThreadAndJoin()
     // join (never returns to the caller from here unless thread is terminated, see KERNEL_DYNAMIC),
     // a stop signal is sent by IPlatform::Stop() by the last exiting task
     if (m_timer_thread != nullptr)
+    {
         WaitForSingleObject(m_timer_thread, INFINITE);
+    }
 }
 
 void Context::Cleanup()
@@ -609,9 +618,8 @@ bool Context::InitStack(EStackType stack_type, Stack *stack, IStackMemory *stack
 {
     InitStackMemory(stack_memory);
 
-    Word * const stack_mem = const_cast<Word *>(stack_memory->GetStack());
-
-    TaskContext * const ctx = reinterpret_cast<TaskContext *>(STK_X86_WIN32_GET_SP(stack_mem));
+    Word *const stack_mem = const_cast<Word *>(stack_memory->GetStack());
+    TaskContext *const ctx = reinterpret_cast<TaskContext *>(STK_X86_WIN32_GET_SP(stack_mem));
 
     switch (stack_type)
     {
@@ -628,6 +636,10 @@ bool Context::InitStack(EStackType stack_type, Stack *stack, IStackMemory *stack
 
     case STACK_EXIT_TRAP: {
         GetContext().m_exit_trap = stack;
+        break; }
+
+    default: {
+        STK_ASSERT(false);
         break; }
     }
 

--- a/test/generic/stktest_kernel.cpp
+++ b/test/generic/stktest_kernel.cpp
@@ -37,7 +37,7 @@ public:
     {
         m_fsm_state_mock = KernelMock::FSM_STATE_MAX + (max_val ? 0 : 1);
 
-        Stack *idle = nullptr, *active = this->m_task_now->GetUserStack();
+        Stack *idle = nullptr, *active = nullptr;
         KernelMock::UpdateFsmState(idle, active);
     }
 };
@@ -72,11 +72,11 @@ TEST(Kernel, State)
 
     CHECK_TRUE(platform != NULL);
 
-    CHECK_TRUE(kernel.GetState() == IKernel::STATE_INACTIVE);
+    CHECK_TRUE(kernel.GetState() == IKernel::KSTATE_INACTIVE);
 
     kernel.Initialize();
 
-    CHECK_TRUE(kernel.GetState() == IKernel::STATE_READY);
+    CHECK_TRUE(kernel.GetState() == IKernel::KSTATE_READY);
 
     CHECK_TRUE(IKernelService::GetInstance() != NULL);
     CHECK_TRUE(IKernelService::GetInstance() == platform->m_service);
@@ -84,7 +84,7 @@ TEST(Kernel, State)
     kernel.AddTask(&task);
     kernel.Start();
 
-    CHECK_TRUE(kernel.GetState() == IKernel::STATE_RUNNING);
+    CHECK_TRUE(kernel.GetState() == IKernel::KSTATE_RUNNING);
 }
 
 TEST(Kernel, InitDoubleFail)
@@ -128,19 +128,24 @@ TEST(Kernel, AddTask)
     Kernel<KERNEL_STATIC, 1, SwitchStrategyRR, PlatformTestMock> kernel;
     TaskMock<ACCESS_USER> task;
     const ITaskSwitchStrategy *strategy = kernel.GetSwitchStrategy();
+    PlatformTestMock *platform = static_cast<PlatformTestMock *>(kernel.GetPlatform());
 
     kernel.Initialize();
 
-    CHECK_EQUAL_TEXT(0, strategy->GetSize(), "Expecting none kernel tasks");
+    CHECK_EQUAL(0, strategy->GetSize()); // Expecting none kernel tasks
 
     kernel.AddTask(&task);
 
-    CHECK_EQUAL_TEXT(1, strategy->GetSize(), "Expecting 1 kernel task");
+    CHECK_EQUAL(1, strategy->GetSize()); // Expecting 1 kernel task
 
     IKernelTask *ktask = strategy->GetFirst();
-    CHECK_TRUE_TEXT(ktask != NULL, "Expecting one kernel task");
+    CHECK_TRUE(ktask != NULL); // Expecting added kernel task
 
-    CHECK_TRUE_TEXT(ktask->GetUserTask() == &task, "Expecting just added user task");
+    CHECK_EQUAL(&task, ktask->GetUserTask()); // Expecting just added user task
+
+    // stack info must belong to this task
+    CHECK_EQUAL(platform->m_stack_info[STACK_USER_TASK].stack->SP, ktask->GetUserStack().SP);
+    CHECK_EQUAL(ACCESS_USER, ktask->GetUserStack().access_mode);
 }
 
 TEST(Kernel, AddTaskInitStack)
@@ -477,7 +482,7 @@ TEST(Kernel, StartBeginISR)
     kernel.Start();
 
     // expect that first task's access mode is requested by kernel
-    CHECK_EQUAL(ACCESS_PRIVILEGED, platform->m_stack_active->mode);
+    CHECK_EQUAL(ACCESS_PRIVILEGED, platform->m_stack_active->access_mode);
 }
 
 TEST(Kernel, ContextSwitchOnSysTickISR)
@@ -540,13 +545,13 @@ TEST(Kernel, ContextSwitchAccessModeChange)
     kernel.Start();
 
     // 1-st task
-    CHECK_EQUAL(ACCESS_USER, platform->m_stack_active->mode);
+    CHECK_EQUAL(ACCESS_USER, platform->m_stack_active->access_mode);
 
     // ISR calls OnSysTick
     platform->ProcessTick();
 
     // 2-st task
-    CHECK_EQUAL(ACCESS_PRIVILEGED, platform->m_stack_active->mode);
+    CHECK_EQUAL(ACCESS_PRIVILEGED, platform->m_stack_active->access_mode);
 }
 
 TEST(Kernel, ContextSwitchCorruptedFsmMode)
@@ -934,6 +939,30 @@ TEST(Kernel, Hrt)
     CHECK_EQUAL(platform->m_stack_active->SP, (Word)task1.GetStack());
 }
 
+TEST(Kernel, HrtApiForNonHrtTask)
+{
+    Kernel<KERNEL_STATIC, 1, SwitchStrategyRR, PlatformTestMock> kernel;
+    TaskMock<ACCESS_USER> task;
+    const ITaskSwitchStrategy *strategy = kernel.GetSwitchStrategy();
+
+    kernel.Initialize();
+    kernel.AddTask(&task);
+    kernel.Start();
+
+    IKernelTask *ktask = strategy->GetFirst();
+    CHECK_TRUE(ktask != NULL); // Expecting added kernel task
+
+    g_TestContext.ExpectAssert(true);
+    g_TestContext.RethrowAssertException(false);
+
+    CHECK_EQUAL(0, ktask->GetHrtPeriodicity());
+    CHECK_EQUAL(0, ktask->GetHrtDeadline());
+    CHECK_EQUAL(0, ktask->GetHrtRelativeDeadline());
+
+    g_TestContext.RethrowAssertException(true);
+    g_TestContext.ExpectAssert(false);
+}
+
 TEST(Kernel, HrtAddNonHrt)
 {
     Kernel<KERNEL_STATIC | KERNEL_HRT, 1, SwitchStrategyRR, PlatformTestMock> kernel;
@@ -1034,7 +1063,7 @@ TEST(Kernel, HrtTaskCompleted)
 
     CHECK_EQUAL(0, strategy->GetSize());
 
-    CHECK_EQUAL(IKernel::STATE_READY, kernel.GetState());
+    CHECK_EQUAL(IKernel::KSTATE_READY, kernel.GetState());
 }
 
 static struct HrtTaskDeadlineMissedRelaxCpuContext
@@ -1432,12 +1461,12 @@ TEST(Kernel, SyncTaskExitAfterWait)
     platform->ProcessTick();
 
     // should be still running here, next tick will result in task exit and kernel stop
-    CHECK_EQUAL(IKernel::STATE_RUNNING, kernel.GetState());
+    CHECK_EQUAL(IKernel::KSTATE_RUNNING, kernel.GetState());
 
     platform->ProcessTick();
 
     // should be stopped here
-    CHECK_EQUAL(IKernel::STATE_READY, kernel.GetState());
+    CHECK_EQUAL(IKernel::KSTATE_READY, kernel.GetState());
 }
 
 static struct SyncWaitRelaxCpuContext
@@ -1551,6 +1580,29 @@ TEST(Kernel, SyncWaitTicklessDuration)
     CHECK_EQUAL(true, mutex.m_locked);
 }
 
+TEST(Kernel, CheckWeightLessApi)
+{
+    Kernel<KERNEL_STATIC, 1, SwitchStrategyRR, PlatformTestMock> kernel;
+    TaskMock<ACCESS_USER> task;
+    const ITaskSwitchStrategy *strategy = kernel.GetSwitchStrategy();
+
+    kernel.Initialize();
+    kernel.AddTask(&task);
+    kernel.Start();
+
+    IKernelTask *ktask = strategy->GetFirst();
+    CHECK_TRUE(ktask != NULL); // Expecting added kernel task
+
+    g_TestContext.ExpectAssert(true);
+    g_TestContext.RethrowAssertException(false);
+
+    CHECK_EQUAL(DEFAULT_WEIGHT, ktask->GetWeight());
+    CHECK_EQUAL(DEFAULT_WEIGHT, ktask->GetCurrentWeight());
+
+    g_TestContext.RethrowAssertException(true);
+    g_TestContext.ExpectAssert(false);
+}
+
 static struct SyncFindWeightHigherThanContext
 {
     SyncFindWeightHigherThanContext()
@@ -1637,7 +1689,8 @@ TEST(Kernel, SyncInheritWeight)
     kernel.Start();
 
     IKernelTask *ktasks[2];
-    kernel.EnumerateKernelTasks(ktasks, 2);
+    ArrayView<IKernelTask *> ktasks_view(ktasks, 2);
+    kernel.EnumerateKernelTasks(ktasks_view);
 
     // current weight is dynamic value used by strategy with PRIORITY_INHERITANCE_API, if not overridden
     // by InheritWeight should be NO_WEIGHT
@@ -1756,7 +1809,7 @@ TEST(Kernel, SuspendResume)
     Timeout ticks = stk::IKernelService::GetInstance()->Suspend();
     CHECK_EQUAL(9, ticks);
 
-    CHECK_EQUAL(IKernel::STATE_SUSPENDED, kernel.GetState());
+    CHECK_EQUAL(IKernel::KSTATE_SUSPENDED, kernel.GetState());
 
     stk::IKernelService::GetInstance()->Resume(ticks);
 }

--- a/test/generic/stktest_switchstrategymonotonic.cpp
+++ b/test/generic/stktest_switchstrategymonotonic.cpp
@@ -95,17 +95,8 @@ TEST(SwitchStrategyMonotonic, GetNextEmpty)
     kernel.RemoveTask(&task1);
     CHECK_EQUAL(0, strategy->GetSize());
 
-    try
-    {
-        g_TestContext.ExpectAssert(true);
-        strategy->GetNext();
-        CHECK_TEXT(false, "expecting assertion when empty");
-    }
-    catch (TestAssertPassed &pass)
-    {
-        CHECK(true);
-        g_TestContext.ExpectAssert(false);
-    }
+    // expect to return NULL which puts core into a sleep mode, current is ignored by this strategy
+    CHECK_EQUAL(0, strategy->GetNext());
 }
 
 template <class _SwitchStrategy>


### PR DESCRIPTION
- Rename `IKernel::EState` to `IKernel::EKernelState` and its members from `STATE_` to `KSTATE_` to resolve  ambiguity with task state. 
- Make `EnumerateTasks`, `EnumerateKernelTasks` safe by using `stk::ArrayView` wrapper for arrays.