### PR TITLE
Refactor C interface to comply with MISRA standard.

### DIFF
--- a/interop/c/include/stk_c.h
+++ b/interop/c/include/stk_c.h
@@ -10,10 +10,17 @@
 #ifndef STK_C_H_
 #define STK_C_H_
 
-#include <stdint.h>
-#include <stddef.h>
-#include <stdbool.h>
-#include <assert.h>
+#ifdef __cplusplus
+    #include <cstdint>
+    #include <cstddef>
+    #include <cstdbool>
+    #include <cassert>
+#else
+    #include <stdint.h>
+    #include <stddef.h>
+    #include <stdbool.h>
+    #include <assert.h>
+#endif
 
 #include <stk_config.h>
 
@@ -66,6 +73,17 @@ extern "C" {
     \brief     Assertion macro used inside STK C bindings
 */
 #define STK_C_ASSERT(e) assert(e)
+  
+/*! \def       STK_STATIC_CAST
+    \brief     Convenience wrapper for static_cast and C-style cast.
+    \param[in] type: Value type.
+    \param[in] val: Value.
+*/
+#ifdef __cplusplus
+    #define STK_STATIC_CAST(type, val) static_cast<type>(val)
+#else
+    #define STK_STATIC_CAST(type, val) ((type)(val))
+#endif
 
 // =============================================================================
 // Types
@@ -99,6 +117,10 @@ typedef int32_t stk_timeout_t;
 */
 typedef uint64_t stk_cycle_t;
 
+/*! \brief     Task weight value.
+*/
+typedef int32_t stk_weight_t;
+
 /*! \brief     Opaque handle to a kernel instance.
 */
 typedef struct stk_kernel_t stk_kernel_t;
@@ -122,11 +144,11 @@ typedef void (*stk_task_entry_t)(void *arg);
 
 /*! \brief     Infinite timeout constant.
 */
-#define STK_WAIT_INFINITE ((stk_timeout_t)(INT32_MAX))
+#define STK_WAIT_INFINITE (STK_STATIC_CAST(stk_timeout_t, INT32_MAX))
 
 /*! \brief     No timeout constant.
 */
-#define STK_NO_WAIT ((stk_timeout_t)(0))
+#define STK_NO_WAIT (STK_STATIC_CAST(stk_timeout_t, 0))
 
 /*! \brief     Memory buffer alignment.
 */
@@ -134,18 +156,18 @@ typedef void (*stk_task_entry_t)(void *arg);
 
 /*! \brief     Alignment mask.
 */
-#define STK_ALIGN_MASK (STK_ALIGN_SIZE - 1)
+#define STK_ALIGN_MASK (STK_ALIGN_SIZE - 1U)
 
 /*! \def       STK_STACK_MEMORY_ALIGN
     \brief     Stack memory alignment.
 */
 #ifndef STK_STACK_MEMORY_ALIGN
     #if defined(__riscv)
-        #define STK_STACK_MEMORY_ALIGN 16U
+        #define STK_STACK_MEMORY_ALIGN (16U)
     #elif defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_X64)
-        #define STK_STACK_MEMORY_ALIGN 8U
+        #define STK_STACK_MEMORY_ALIGN (8U)
     #else // ARM, others
-        #define STK_STACK_MEMORY_ALIGN 4U
+        #define STK_STACK_MEMORY_ALIGN (4U)
     #endif
 #endif
 
@@ -166,7 +188,7 @@ typedef void (*stk_task_entry_t)(void *arg);
     \see       STK_DEFINE_STACK_POOL
 */
 #define STK_GET_STACK_FROM_POOL(name, task_id) (name[task_id])
-
+   
 // =============================================================================
 // Attributes
 // =============================================================================
@@ -514,10 +536,10 @@ void stk_kernel_set_event_overrider(stk_kernel_t *k, stk_event_overrider_t *over
     \param[in] stack_size: Number of elements (words) in the stack buffer.
     \return    Task handle (static storage in static kernels, heap in dynamic).
 */
-stk_task_t *stk_task_create_privileged(stk_task_entry_t entry,
-                                       void *arg,
-                                       stk_word_t *stack,
-                                       uint32_t stack_size);
+stk_task_t *stk_task_create_privileged(stk_task_entry_t  entry,
+                                       void             *arg,
+                                       stk_word_t       *stack,
+                                       uint32_t          stack_size);
 
 /*! \brief     Create user-mode task.
     \param[in] entry: Task entry function.
@@ -526,10 +548,10 @@ stk_task_t *stk_task_create_privileged(stk_task_entry_t entry,
     \param[in] stack_size: Number of elements (words) in the stack buffer.
     \return    Task handle.
 */
-stk_task_t *stk_task_create_user(stk_task_entry_t entry,
-                                 void *arg,
-                                 stk_word_t *stack,
-                                 uint32_t stack_size);
+stk_task_t *stk_task_create_user(stk_task_entry_t  entry,
+                                 void             *arg,
+                                 stk_word_t       *stack,
+                                 uint32_t          stack_size);
 
 /*! \brief     Set task weight (used only by Smooth Weighted Round Robin).
     \param[in] task: Task handle.
@@ -537,7 +559,7 @@ stk_task_t *stk_task_create_user(stk_task_entry_t entry,
     \note      Must be called before adding task to kernel.
     \see       SwitchStrategySmoothWeightedRoundRobin.
 */
-void stk_task_set_weight(stk_task_t *task, uint32_t weight);
+void stk_task_set_weight(stk_task_t *task, stk_weight_t weight);
 
 /*! \brief     Set task priority (used only by Fixed Priority scheduler).
     \param[in] task: Task handle.
@@ -606,7 +628,15 @@ stk_tick_t stk_ticks_from_ms(stk_time_t msec);
 */
 static inline stk_tick_t stk_ticks_from_ms_r(stk_time_t msec, uint32_t resolution)
 {
-    return ((resolution != 0U) ? (msec * 1000LL / (stk_time_t)resolution) : 0LL);
+    stk_time_t result = 0LL;
+    
+    if (resolution != 0U)
+    {
+        const stk_time_t total_scaled = msec * 1000LL;
+        result = total_scaled / STK_STATIC_CAST(stk_time_t, resolution);
+    }
+
+    return STK_STATIC_CAST(stk_tick_t, result);
 }
 
 /*! \brief     Returns current time in milliseconds since kernel start.
@@ -622,7 +652,8 @@ stk_time_t stk_time_now_ms(void);
 */
 static inline stk_time_t stk_ms_from_ticks_r(stk_tick_t ticks, uint32_t resolution)
 {
-    return (stk_time_t)((ticks * (stk_tick_t)resolution) / 1000LL);
+    const stk_tick_t total_ticks = ticks * STK_STATIC_CAST(stk_tick_t, resolution);
+    return STK_STATIC_CAST(stk_time_t, total_ticks / 1000LL);
 }
 
 /*! \brief     Convert ticks to milliseconds using the current kernel tick resolution.
@@ -706,6 +737,7 @@ void stk_sleep_ms(stk_timeout_t ms);
 
 /*! \brief     Put current task to sleep (non-HRT kernels only).
     \param[in] ts: Absolute time, a deadline for a sleep period.
+    \return    True if sleep succeeded, false otherwise.
     \note      Unlike stk_delay_ms(), this function does not spin and allows the kernel to
                idle the CPU. When \a KERNEL_TICKLESS is active and all tasks are sleeping,
                the SysTick is suppressed and the CPU enters a low-power WFI state until the
@@ -714,7 +746,7 @@ void stk_sleep_ms(stk_timeout_t ms);
                according to their periodicity and workload, use stk_yield instead.
     \see       stk_sleep, stk_sleep_ms, stk_ticks
 */
-void stk_sleep_until(stk_tick_t ts);
+bool stk_sleep_until(stk_tick_t ts);
 
 /*! \brief     Voluntarily give up CPU to another ready task (cooperative yield).
 */
@@ -808,7 +840,7 @@ void stk_critical_section_exit(void);
 
 /*! \brief     A memory size (multiples of stk_word_t) required for Mutex instance.
 */
-#define STK_MUTEX_IMPL_SIZE (10 + (STK_SYNC_DEBUG_NAMES ? 1 : 0))
+#define STK_MUTEX_IMPL_SIZE (10U + (STK_SYNC_DEBUG_NAMES ? 1U : 0U))
 
 /*! \brief     Opaque memory container for a Mutex instance.
 */
@@ -821,11 +853,11 @@ typedef struct stk_mutex_mem_t {
 typedef struct stk_mutex_t stk_mutex_t;
 
 /*! \brief     Create a Mutex (using provided memory).
-    \param[in] memory: Pointer to static memory container.
-    \param[in] memory_size: Size of the container (must be >= sizeof(stk_mutex_mem_t)).
+    \param[in] membuf: Pointer to static memory container.
+    \param[in] membuf_size: Size of the container (must be >= sizeof(stk_mutex_mem_t)).
     \return    Mutex handle.
 */
-stk_mutex_t *stk_mutex_create(stk_mutex_mem_t *memory, uint32_t memory_size);
+stk_mutex_t *stk_mutex_create(stk_mutex_mem_t *const membuf, uint32_t membuf_size);
 
 /*! \brief     Destroy a Mutex.
     \param[in] mtx: Mutex handle.
@@ -873,34 +905,34 @@ typedef struct {
 typedef struct stk_spinlock_t stk_spinlock_t;
 
 /*! \brief     Create a recursive SpinLock.
-    \param[in] memory: Pointer to static memory container.
-    \param[in] memory_size: Size of the container (must be >= sizeof(stk_spinlock_mem_t)).
+    \param[in] membuf: Pointer to static memory container.
+    \param[in] membuf_size: Size of the container (must be >= sizeof(stk_spinlock_mem_t)).
     \return    SpinLock handle.
 */
-stk_spinlock_t *stk_spinlock_create(stk_spinlock_mem_t *memory, uint32_t memory_size);
+stk_spinlock_t *stk_spinlock_create(stk_spinlock_mem_t *const membuf, uint32_t membuf_size);
 
 /*! \brief     Destroy the SpinLock.
 */
-void stk_spinlock_destroy(stk_spinlock_t *lock);
+void stk_spinlock_destroy(stk_spinlock_t *slock);
 
 /*! \brief     Acquire the SpinLock (recursive).
 */
-void stk_spinlock_lock(stk_spinlock_t *lock);
+void stk_spinlock_lock(stk_spinlock_t *slock);
 
 /*! \brief     Attempt to acquire the SpinLock immediately.
     \return    True if locked successfully, False otherwise.
 */
-bool stk_spinlock_trylock(stk_spinlock_t *lock);
+bool stk_spinlock_trylock(stk_spinlock_t *slock);
 
 /*! \brief     Release the SpinLock.
 */
-void stk_spinlock_unlock(stk_spinlock_t *lock);
+void stk_spinlock_unlock(stk_spinlock_t *slock);
 
 // ----- Condition Variable ----------------------------------------------------
 
 /*! \brief     A memory size (multiples of stk_word_t) required for ConditionVariable instance.
 */
-#define STK_CV_IMPL_SIZE (7 + (STK_SYNC_DEBUG_NAMES ? 1 : 0))
+#define STK_CV_IMPL_SIZE (7U + (STK_SYNC_DEBUG_NAMES ? 1U : 0U))
 
 /*! \brief     Opaque memory container for a ConditionVariable instance.
 */
@@ -913,11 +945,11 @@ typedef struct stk_cv_mem_t {
 typedef struct stk_cv_t stk_cv_t;
 
 /*! \brief     Create a Condition Variable (using provided memory).
-    \param[in] memory:      Pointer to static memory container.
-    \param[in] memory_size: Size of the container (must be >= sizeof(stk_cv_mem_t)).
+    \param[in] membuf:      Pointer to static memory container.
+    \param[in] membuf_size: Size of the container (must be >= sizeof(stk_cv_mem_t)).
     \return    CV handle.
 */
-stk_cv_t *stk_cv_create(stk_cv_mem_t *memory, uint32_t memory_size);
+stk_cv_t *stk_cv_create(stk_cv_mem_t *const membuf, uint32_t membuf_size);
 
 /*! \brief     Destroy a Condition Variable.
     \param[in] cv: CV handle.
@@ -948,7 +980,7 @@ void stk_cv_notify_all(stk_cv_t *cv);
 
 /*! \brief     A memory size (multiples of stk_word_t) required for Event instance.
 */
-#define STK_EVENT_IMPL_SIZE (8 + (STK_SYNC_DEBUG_NAMES ? 1 : 0))
+#define STK_EVENT_IMPL_SIZE (8U + (STK_SYNC_DEBUG_NAMES ? 1U : 0U))
 
 /*! \brief     Opaque memory container for an Event instance.
 */
@@ -961,12 +993,14 @@ typedef struct stk_event_mem_t {
 typedef struct stk_event_t stk_event_t;
 
 /*! \brief     Create an Event (using provided memory).
-    \param[in] memory: Pointer to static memory container.
-    \param[in] memory_size: Size of the container (must be >= sizeof(stk_event_mem_t)).
+    \param[in] membuf: Pointer to static memory container.
+    \param[in] membuf_size: Size of the container (must be >= sizeof(stk_event_mem_t)).
     \param[in] manual_reset: True for manual-reset, False for auto-reset.
     \return    Event handle.
 */
-stk_event_t *stk_event_create(stk_event_mem_t *memory, uint32_t memory_size, bool manual_reset);
+stk_event_t *stk_event_create(stk_event_mem_t *const membuf, 
+                              uint32_t         membuf_size, 
+                              bool             manual_reset);
 
 /*! \brief     Destroy an Event.
     \param[in] ev: Event handle.
@@ -988,13 +1022,17 @@ bool stk_event_trywait(stk_event_t *ev);
 
 /*! \brief     Set the event to signaled state.
     \param[in] ev: Event handle.
+    \return    \c true if state was changed from non-signaled to signaled,
+               \c false if event was already signaled.
 */
-void stk_event_set(stk_event_t *ev);
+bool stk_event_set(stk_event_t *ev);
 
 /*! \brief     Reset the event to non-signaled state.
     \param[in] ev: Event handle.
+    \return    \c true if state was changed from signaled to non-signaled,
+               \c false if event was already non-signaled.
 */
-void stk_event_reset(stk_event_t *ev);
+bool stk_event_reset(stk_event_t *ev);
 
 /*! \brief     Pulse the event (signal then immediately reset).
     \param[in] ev: Event handle.
@@ -1005,7 +1043,7 @@ void stk_event_pulse(stk_event_t *ev);
 
 /*! \brief     A memory size (multiples of stk_word_t) required for Semaphore instance.
 */
-#define STK_SEM_IMPL_SIZE (8 + (STK_SYNC_DEBUG_NAMES ? 1 : 0))
+#define STK_SEM_IMPL_SIZE (8U + (STK_SYNC_DEBUG_NAMES ? 1U : 0U))
 
 /*! \brief     Opaque memory container for a Semaphore instance.
 */
@@ -1018,15 +1056,17 @@ typedef struct stk_sem_mem_t {
 typedef struct stk_sem_t stk_sem_t;
 
 /*! \brief     Create a Semaphore (using provided memory).
-    \param[in] memory: Pointer to static memory container.
-    \param[in] memory_size: Size of the container (must be >= sizeof(stk_sem_mem_t)).
+    \param[in] membuf: Pointer to static memory container.
+    \param[in] membuf_size: Size of the container (must be >= sizeof(stk_sem_mem_t)).
     \param[in] initial_count: Starting value of the resource counter.
     \param[in] max_count: Maximum value the counter is allowed to reach.
                Pass 0 to use the default maximum (65534). Must be > initial_count.
     \return    Semaphore handle.
 */
-stk_sem_t *stk_sem_create(stk_sem_mem_t *memory, uint32_t memory_size,
-                           uint32_t initial_count, uint32_t max_count);
+stk_sem_t *stk_sem_create(stk_sem_mem_t *const membuf, 
+                          uint32_t       membuf_size,
+                          uint32_t       initial_count, 
+                          uint32_t       max_count);
 
 /*! \brief     Destroy a Semaphore.
     \param[in] sem: Semaphore handle.
@@ -1080,13 +1120,16 @@ uint16_t stk_sem_get_count(const stk_sem_t *sem);
 /*! \brief     Returns true if a value returned by stk_ef_set(), stk_ef_clear(),
                stk_ef_wait(), or stk_ef_trywait() is an error sentinel (bit 31 set).
 */
-static inline bool stk_ef_is_error(uint32_t result) { return ((result & STK_EF_ERROR_MASK) != 0U); }
+static inline bool stk_ef_is_error(uint32_t result) 
+{ 
+    return ((result & STK_EF_ERROR_MASK) != 0U); 
+}
 
 /*! \brief     A memory size (multiples of stk_word_t) required for EventFlags instance.
     \note      EventFlags contains one ConditionVariable (STK_CV_IMPL_SIZE words)
                plus one 32-bit flags word and alignment padding.
 */
-#define STK_EF_IMPL_SIZE (STK_CV_IMPL_SIZE + 1 + (STK_SYNC_DEBUG_NAMES ? 1 : 0))
+#define STK_EF_IMPL_SIZE (STK_CV_IMPL_SIZE + 1U + (STK_SYNC_DEBUG_NAMES ? 1U : 0U))
 
 /*! \brief     Opaque memory container for an EventFlags instance.
 */
@@ -1099,13 +1142,15 @@ typedef struct stk_ef_mem_t {
 typedef struct stk_ef_t stk_ef_t;
 
 /*! \brief     Create an EventFlags object (using provided memory).
-    \param[in] memory: Pointer to static memory container.
-    \param[in] memory_size: Size of the container (must be >= sizeof(stk_ef_mem_t)).
+    \param[in] membuf: Pointer to static memory container.
+    \param[in] membuf_size: Size of the container (must be >= sizeof(stk_ef_mem_t)).
     \param[in] initial_flags: Initial value of the 32-bit flags word (bits 0..30 only;
                bit 31 is reserved and must not be set).
     \return    EventFlags handle, or NULL if memory is too small.
 */
-stk_ef_t *stk_ef_create(stk_ef_mem_t *memory, uint32_t memory_size, uint32_t initial_flags);
+stk_ef_t *stk_ef_create(stk_ef_mem_t *const membuf, 
+                        uint32_t      membuf_size,
+                        uint32_t      initial_flags);
 
 /*! \brief     Destroy an EventFlags object.
     \param[in] ef: EventFlags handle.
@@ -1180,7 +1225,7 @@ uint32_t stk_ef_trywait(stk_ef_t *ef, uint32_t flags, uint32_t options);
     \note      The backing data buffer is allocated separately by the caller and
                passed to stk_pipe_create() via the \a buf / \a buf_size parameters.
 */
-#define STK_PIPE_IMPL_SIZE (6 + (2 * STK_CV_IMPL_SIZE) + (STK_SYNC_DEBUG_NAMES ? 1 : 0))
+#define STK_PIPE_IMPL_SIZE (6U + (2U * STK_CV_IMPL_SIZE) + (STK_SYNC_DEBUG_NAMES ? 1U : 0U))
 
 /*! \brief     Opaque memory container for a Pipe control-block.
 */
@@ -1213,13 +1258,13 @@ typedef struct stk_pipe_t stk_pipe_t;
     ((((capacity) * (element_size)) + STK_ALIGN_MASK) & ~STK_ALIGN_MASK)
 
 /*! \brief     Create a Pipe (using provided memory).
-    \details   Constructs a stk::sync::Pipe in-place inside \a memory. The pipe will
+    \details   Constructs a stk::sync::Pipe in-place inside \a membuf. The pipe will
                hold up to \a capacity elements, each \a element_size bytes wide.
                The backing ring-buffer storage must be supplied by the caller via
                \a buf / \a buf_size.
-    \param[in] memory: Pointer to static memory container for the Pipe control-block.
+    \param[in] membuf: Pointer to static memory container for the Pipe control-block.
                Must be at least sizeof(stk_pipe_mem_t) bytes.
-    \param[in] memory_size: Size of \a memory in bytes.
+    \param[in] membuf_size: Size of \a membuf in bytes.
     \param[in] buf: Pointer to the element data buffer.
                Must be at least \a capacity * \a element_size bytes.
     \param[in] buf_size: Size of \a buf in bytes (used for the safety assertion;
@@ -1231,8 +1276,8 @@ typedef struct stk_pipe_t stk_pipe_t;
                the required \a buf_size.
     \note      Only available when kernel is compiled with \a KERNEL_SYNC mode enabled.
 */
-stk_pipe_t *stk_pipe_create(stk_pipe_mem_t *memory,
-                            uint32_t        memory_size,
+stk_pipe_t *stk_pipe_create(stk_pipe_mem_t *const membuf,
+                            uint32_t        membuf_size,
                             uint8_t        *buf,
                             uint32_t        buf_size,
                             size_t          capacity,
@@ -1468,14 +1513,14 @@ typedef struct stk_msgq_t stk_msgq_t;
 #define STK_MSGQ_BUF_SIZE(capacity, msg_size) ((capacity) * (msg_size))
 
 /*! \brief     Create a MessageQueue (using provided memory).
-    \details   Constructs a stk::sync::MessageQueue in-place inside \a memory.
+    \details   Constructs a stk::sync::MessageQueue in-place inside \a membuf.
                The queue will hold up to \a capacity messages, each \a msg_size bytes
                wide.  The backing storage for messages must be supplied by the caller
                via \a buf / \a buf_size.
 
-    \param[in] memory: Pointer to static memory container for the queue object.
+    \param[in] membuf: Pointer to static memory container for the queue object.
                Must be at least sizeof(stk_msgq_mem_t) bytes.
-    \param[in] memory_size: Size of \a memory in bytes (must be >= sizeof(stk_msgq_mem_t)).
+    \param[in] membuf_size: Size of \a membuf in bytes (must be >= sizeof(stk_msgq_mem_t)).
     \param[in] buf: Pointer to the message data buffer.
                Must be at least \a capacity * \a msg_size bytes.
     \param[in] buf_size: Size of \a buf in bytes (used only for the safety assertion; must equal
@@ -1488,12 +1533,12 @@ typedef struct stk_msgq_t stk_msgq_t;
                the required \a buf_size.
     \note      Only available when kernel is compiled with \a KERNEL_SYNC mode enabled.
 */
-stk_msgq_t *stk_msgq_create(stk_msgq_mem_t *memory,
-                             uint32_t        memory_size,
-                             uint8_t        *buf,
-                             uint32_t        buf_size,
-                             size_t          capacity,
-                             size_t          msg_size);
+stk_msgq_t *stk_msgq_create(stk_msgq_mem_t *const membuf,
+                            uint32_t        membuf_size,
+                            uint8_t        *buf,
+                            uint32_t        buf_size,
+                            size_t          capacity,
+                            size_t          msg_size);
 
 /*! \brief     Destroy a MessageQueue.
     \param[in] mq: MessageQueue handle.
@@ -1684,7 +1729,7 @@ bool stk_msgq_is_storage_valid(const stk_msgq_t *mq);
 
 /*! \brief     A memory size (multiples of stk_word_t) required for RWMutex instance.
 */
-#define STK_RWMUTEX_IMPL_SIZE (17 + (STK_SYNC_DEBUG_NAMES ? 3 : 0))
+#define STK_RWMUTEX_IMPL_SIZE (17U + (STK_SYNC_DEBUG_NAMES ? 3U : 0U))
 
 /*! \brief     Opaque memory container for an RWMutex instance.
 */
@@ -1697,11 +1742,11 @@ typedef struct stk_rwmutex_mem_t {
 typedef struct stk_rwmutex_t stk_rwmutex_t;
 
 /*! \brief     Create an RWMutex (using provided memory).
-    \param[in] memory: Pointer to static memory container.
-    \param[in] memory_size: Size of the container (must be >= sizeof(stk_rwmutex_mem_t)).
+    \param[in] membuf: Pointer to static memory container.
+    \param[in] membuf_size: Size of the container (must be >= sizeof(stk_rwmutex_mem_t)).
     \return    RWMutex handle, or NULL if memory is too small.
 */
-stk_rwmutex_t *stk_rwmutex_create(stk_rwmutex_mem_t *memory, uint32_t memory_size);
+stk_rwmutex_t *stk_rwmutex_create(stk_rwmutex_mem_t *const membuf, uint32_t membuf_size);
 
 /*! \brief     Destroy an RWMutex.
     \param[in] rw: RWMutex handle.

--- a/interop/c/include/stk_c_memory.h
+++ b/interop/c/include/stk_c_memory.h
@@ -71,7 +71,7 @@ extern "C" {
     \note    Increase if your application needs more simultaneous pools.
 */
 #ifndef STK_C_BLOCKPOOL_MAX
-    #define STK_C_BLOCKPOOL_MAX 8U
+    #define STK_C_BLOCKPOOL_MAX (8U)
 #endif
 
 // =============================================================================
@@ -214,7 +214,7 @@ void *stk_blockpool_alloc(stk_blockpool_t *pool);
                before a block became available.
     \warning   ISR-safe \b only when \a timeout = \c STK_NO_WAIT; not ISR-safe otherwise.
 */
-void *stk_blockpool_timed_alloc(stk_blockpool_t *pool, uint32_t timeout);
+void *stk_blockpool_timed_alloc(stk_blockpool_t *pool, stk_timeout_t timeout);
 
 /*! \brief     Non-blocking allocation attempt.
     \details   Returns a block immediately if one is available, or \c NULL if the

--- a/interop/c/include/stk_c_time.h
+++ b/interop/c/include/stk_c_time.h
@@ -45,14 +45,14 @@ extern "C" {
     \note  Increase if your application needs more simultaneous timers.
 */
 #ifndef STK_C_TIMER_MAX
-    #define STK_C_TIMER_MAX 32
+    #define STK_C_TIMER_MAX (32U)
 #endif
 
 /*! \def   STK_C_TIMER_HANDLER_STACK_SIZE
     \brief Stack size of the timer handler, increase if your timers consume more (default: 256).
 */
 #ifndef STK_C_TIMER_HANDLER_STACK_SIZE
-    #define STK_C_TIMER_HANDLER_STACK_SIZE 256
+    #define STK_C_TIMER_HANDLER_STACK_SIZE (256U)
 #endif
 
 // =============================================================================
@@ -209,26 +209,26 @@ bool stk_timer_restart(stk_timerhost_t *host,
     \param[in] host: TimerHost managing the timer.
     \param[in] timer: Timer handle (active or inactive).
     \param[in] delay: Initial delay in ticks (used only when starting).
-    \param[in] period: Reload period in ticks (used only when starting, 0 = one-shot).
+    \param[in] period_ticks: Reload period in ticks (used only when starting, 0 = one-shot).
     \return    \c true on success, \c false if the command queue is full.
 */
 bool stk_timer_start_or_reset(stk_timerhost_t *host,
-                               stk_timer_t     *timer,
-                               uint32_t         delay,
-                               uint32_t         period);
+                              stk_timer_t     *timer,
+                              uint32_t         delay,
+                              uint32_t         period_ticks);
 
 /*! \brief     Change the period of a running periodic timer without affecting the current deadline.
     \details   The new period takes effect on the next reload after the current deadline fires.
                To apply immediately, follow with \a stk_timer_reset().
     \param[in] host: TimerHost managing the timer.
     \param[in] timer: Timer handle.  Must be active and periodic.
-    \param[in] period: New reload period in ticks.  Must be non-zero.
+    \param[in] period_ticks: New reload period in ticks.  Must be non-zero.
     \return    \c true on success, \c false if preconditions are not met or
                the command queue is full.
 */
 bool stk_timer_set_period(stk_timerhost_t *host,
                           stk_timer_t     *timer,
-                          uint32_t         period);
+                          uint32_t         period_ticks);
 
 // =============================================================================
 // Timer query
@@ -290,7 +290,7 @@ uint32_t stk_timer_get_remaining_ticks(const stk_timer_t *timer);
 
 /*! \brief  A memory size (multiples of stk_word_t) required for PeriodicTrigger instance.
 */
-#define STK_PERIODIC_TRIGGER_IMPL_SIZE 16
+#define STK_PERIODIC_TRIGGER_IMPL_SIZE (16U)
 
 /*! \brief  Opaque memory container for a \a stk_periodic_trigger_t instance.
     \note   Declare as \c static or on the stack (not on the heap).
@@ -304,19 +304,19 @@ typedef struct stk_periodic_trigger_mem_t {
 typedef struct stk_periodic_trigger_t stk_periodic_trigger_t;
 
 /*! \brief     Construct PeriodicTrigger instance in the supplied memory buffer.
-    \param[in] memory: Pointer to the caller-supplied memory container.
-    \param[in] memory_size: Size of the container in bytes (must be >= sizeof(stk_periodic_trigger_mem_t)).
-    \param[in] period: Trigger period in ticks. Must be > 0.
+    \param[in] membuf: Pointer to the caller-supplied memory container.
+    \param[in] membuf_size: Size of the container in bytes (must be >= sizeof(stk_periodic_trigger_mem_t)).
+    \param[in] period_ticks: Trigger period in ticks. Must be > 0.
     \param[in] started: \c true to create the instance in a started state (first firing occurs
                no earlier than \a period ticks after construction); \c false to create it in a
                stopped state (call \a stk_periodic_trigger_restart() before polling).
-    \return    Trigger handle on success, or \c NULL if \a memory is \c NULL
+    \return    Trigger handle on success, or \c NULL if \a membuf is \c NULL
                or \a memory_size is too small.
 */
-stk_periodic_trigger_t *stk_periodic_trigger_create(stk_periodic_trigger_mem_t *memory,
-                                                    uint32_t                   memory_size,
-                                                    uint32_t                   period,
-                                                    bool                       started);
+stk_periodic_trigger_t *stk_periodic_trigger_create(stk_periodic_trigger_mem_t *const membuf,
+                                                    uint32_t                    membuf_size,
+                                                    uint32_t                    period_ticks,
+                                                    bool                        started);
 
 /*! \brief     Destroy instance (calls the C++ destructor in-place).
     \param[in] trig: Trigger handle. May be \c NULL (no-op).
@@ -336,16 +336,16 @@ void stk_periodic_trigger_destroy(stk_periodic_trigger_t *trig);
                calls will continue advancing one period at a time until
                the schedule catches up.
 */
-bool stk_periodic_trigger_poll(stk_periodic_trigger_t *trig);
+bool stk_periodic_trigger_poll(stk_periodic_trigger_t *const trig);
 
 /*! \brief     Change the trigger period while preserving phase.
     \param[in] trig: Trigger handle.
-    \param[in] period: New trigger period in ticks. Must be > 0.
+    \param[in] period_ticks: New trigger period in ticks. Must be > 0.
     \note      Adjusts the internally stored next-trigger time so that the
                relative progress toward the next firing is preserved.
                Takes effect immediately.
 */
-void stk_periodic_trigger_set_period(stk_periodic_trigger_t *trig, uint32_t period);
+void stk_periodic_trigger_set_period(stk_periodic_trigger_t *trig, uint32_t period_ticks);
 
 /*! \brief     Reset and start the trigger from the current tick count.
     \param[in] trig: Trigger handle.

--- a/interop/c/src/stk_c.cpp
+++ b/interop/c/src/stk_c.cpp
@@ -36,10 +36,40 @@ using namespace stk;
 
 #define STK_C_TASKS_MAX (STK_C_KERNEL_MAX_TASKS)
 
-static void FreeTask(const stk_task_t *task);
-
 // Forward decl.
 struct stk_task_t;
+
+// Cast from stk_kernel_t to IKernel without a warning.
+static __stk_forceinline IKernel *CastCToKernelInterface(stk_kernel_t *const k)
+{
+    return reinterpret_cast<IKernel *>(reinterpret_cast<void *>(k));
+}
+
+// Cast from const stk_kernel_t to const IKernel without a warning.
+static __stk_forceinline const IKernel *CastCToKernelInterfaceConst(const stk_kernel_t *const k)
+{
+    return reinterpret_cast<const IKernel *>(reinterpret_cast<const void *>(k));
+}
+
+// Cast from IKernel to stk_kernel_t without a warning.
+static __stk_forceinline stk_kernel_t *CastCppKernelInterfaceToC(IKernel *const k)
+{
+    return reinterpret_cast<stk_kernel_t *>(reinterpret_cast<void *>(k));
+}
+
+// Interop-private helpers
+namespace stk {
+namespace interop_c_helper {
+
+extern void InitializeTimerHost(stk_kernel_t *kernel, stk::time::TimerHost *th, EAccessMode amode)
+{
+    th->Initialize(CastCToKernelInterface(kernel), amode);
+}
+
+} // interop_c_helper
+} // stk
+
+static void FreeTask(const stk_task_t *tsk);
 
 class TaskWrapper final : public ITask
 {
@@ -51,7 +81,7 @@ public:
     /*! \brief Destructor.
         \note  MISRA deviation: [STK-DEV-005] Rule 10-3-2.
     */
-    ~TaskWrapper() = default;
+    STK_VIRT_DTOR ~TaskWrapper() = default;
   
     // ITask
     EAccessMode GetAccessMode()              const override { return m_mode; }
@@ -64,7 +94,7 @@ public:
     size_t GetStackSize()      const override { return m_stack_size; }
     size_t GetStackSizeBytes() const override { return m_stack_size * sizeof(stk_word_t); }
 
-    void Initialize(stk_task_entry_t func, void *user_data, stk_word_t *stack,
+    void Initialize(stk_task_entry_t const func, void *user_data, stk_word_t *stack,
         size_t stack_size, EAccessMode mode)
     {
         m_func       = func;
@@ -82,10 +112,7 @@ private:
     STK_NONCOPYABLE_CLASS(TaskWrapper);
   
     void Run() override { m_func(m_user_data); }
-    void OnExit() override { FreeTask(ToStkTask()); }
-
-    //! Warning: stk_task_t::handle must be the first in stk_task_t struct.
-    stk_task_t *ToStkTask() { return reinterpret_cast<stk_task_t *>(this); }
+    void OnExit() override;
 
     stk_task_entry_t m_func;
     void            *m_user_data;
@@ -111,6 +138,17 @@ static struct TaskSlot
 }
 s_Tasks[STK_C_TASKS_MAX];
 
+// Cast from stk_task_t to TaskWrapper without a warning.
+static __stk_forceinline stk_task_t *CastCppTaskInterfaceToC(ITask *const t)
+{
+    return reinterpret_cast<stk_task_t *>(reinterpret_cast<void *>(t));
+}
+
+void TaskWrapper::OnExit() 
+{
+    FreeTask(CastCppTaskInterfaceToC(this)); 
+}
+
 // -----------------------------------------------------------------------------
 // EventOverriderWrapper - bridges stk_event_overrider_t callbacks into the
 // C++ IPlatform::IEventOverrider interface.
@@ -125,6 +163,11 @@ class EventOverrider final : public IPlatform::IEventOverrider
 public:
     EventOverrider() : m_cb(nullptr)
     {}
+
+    /*! \brief Destructor.
+        \note  MISRA deviation: [STK-DEV-005] Rule 10-3-2.
+    */
+    STK_VIRT_DTOR ~EventOverrider() = default;
 
     /*! \brief     Bind or unbind a C-level overrider struct.
         \param[in] c: Pointer to a caller-owned stk_event_overrider_t, or nullptr
@@ -183,7 +226,7 @@ static void RegisterKernel(IKernel *k, uint8_t core_nr)
 
 static void UnregisterKernel(const IKernel *k)
 {
-    for (uint32_t i = 0; i < STK_C_CPU_COUNT; ++i)
+    for (uint32_t i = 0U; i < STK_C_CPU_COUNT; ++i)
     {
         if (s_KernelMap[i].kernel == k)
         {
@@ -196,73 +239,77 @@ static void UnregisterKernel(const IKernel *k)
 
 static void SetEventOverrider(IKernel *k, stk_event_overrider_t *overrider)
 {
-    for (uint32_t i = 0; i < STK_C_CPU_COUNT; ++i)
+    bool found = false;
+
+    for (uint32_t i = 0U; (i < STK_C_CPU_COUNT) && (!found); ++i)
     {
         if (s_KernelMap[i].kernel == k)
         {
             s_KernelMap[i].event_cb.SetCallback(overrider);
             k->GetPlatform()->SetEventOverrider(
-                (overrider != nullptr ? &s_KernelMap[i].event_cb : nullptr));
-            return;
+                (overrider != nullptr) ? &s_KernelMap[i].event_cb : nullptr);
+            found = true;
         }
     }
 
     // Kernel not found: stk_kernel_set_event_overrider() called before
     // stk_kernel_create() or after stk_kernel_destroy().
-    STK_ASSERT(false);
+    STK_ASSERT(found);
 }
 
 // -----------------------------------------------------------------------------
 // Helpers
 // -----------------------------------------------------------------------------
 
-static stk_task_t *AllocateTask(stk_task_entry_t entry,
-                                void *arg,
-                                stk_word_t *stack,
-                                uint32_t stack_size,
-                                EAccessMode mode)
+static stk_task_t *AllocateTask(stk_task_entry_t  entry,
+                                void             *arg,
+                                stk_word_t       *stack,
+                                uint32_t          stack_size,
+                                EAccessMode       amode)
 {
-    stk_task_t *task = nullptr;
+    stk_task_t *tsk = nullptr;
 
-    sync::ScopedCriticalSection __cs;
+    const sync::ScopedCriticalSection __cs;
 
-    for (uint32_t i = 0; i < STK_C_TASKS_MAX; ++i)
+    for (uint32_t i = 0U; i < STK_C_TASKS_MAX; ++i)
     {
         if (!s_Tasks[i].busy)
         {
             s_Tasks[i].busy = true;
 
-            task = &s_Tasks[i].task;
-            task->handle.Initialize(entry, arg, stack, stack_size, mode);
+            tsk = &s_Tasks[i].task;
+            tsk->handle.Initialize(entry, arg, stack, stack_size, amode);
             break;
         }
     }
 
-    STK_ASSERT(task != nullptr);
-    return task;
+    STK_ASSERT(tsk != nullptr);
+    return tsk;
 }
 
-void FreeTask(const stk_task_t *task)
+void FreeTask(const stk_task_t *tsk)
 {
-    sync::ScopedCriticalSection __cs;
+    bool found = false;
+    
+    const sync::ScopedCriticalSection __cs;
 
-    for (uint32_t i = 0; i < STK_C_TASKS_MAX; ++i)
+    for (uint32_t i = 0U; ((i < STK_C_TASKS_MAX) && !found); ++i)
     {
-        if (s_Tasks[i].busy && (task == &s_Tasks[i].task))
+        if (s_Tasks[i].busy && (tsk == &s_Tasks[i].task))
         {
             s_Tasks[i].busy = false;
-            return;
+            found = true;
         }
     }
 
-    STK_ASSERT(false);
+    STK_ASSERT(found);
 }
 
 // =============================================================================
 // C-interface
 // =============================================================================
 extern "C" {
-
+ 
 // -----------------------------------------------------------------------------
 // Kernel create/destroy wrappers
 // -----------------------------------------------------------------------------
@@ -278,15 +325,17 @@ extern "C" {
                             "Kernel memory size must be multiple of Word"); \
         alignas(alignof(KernelType_)) \
         static Word STK_KERNEL_MEM(X)[sizeof(KernelType_) / sizeof(Word)]; \
-        IKernel *kernel = new (STK_KERNEL_MEM(X)) KernelType_(); \
-        RegisterKernel(kernel, X); \
-        return reinterpret_cast<stk_kernel_t *>(kernel); \
+        k = new (STK_KERNEL_MEM(X)) KernelType_(); \
+        RegisterKernel(k, static_cast<uint8_t>(X)); \
+        break; \
     }
 
 stk_kernel_t *stk_kernel_create(uint8_t core_nr)
 {
-    STK_STATIC_ASSERT(STK_C_CPU_COUNT <= 8); // switch (core_nr) below handles cases 0..7; STK_C_KERNEL_TYPE_CPU_N is only defined up to N=7
+    STK_STATIC_ASSERT((STK_C_CPU_COUNT <= 8U)); // switch (core_nr) below handles cases 0..7; STK_C_KERNEL_TYPE_CPU_N is only defined up to N=7
     STK_ASSERT(core_nr < STK_C_CPU_COUNT);
+
+    IKernel *k;
 
     switch (core_nr)
     {
@@ -314,9 +363,12 @@ stk_kernel_t *stk_kernel_create(uint8_t core_nr)
 #ifdef STK_C_KERNEL_TYPE_CPU_7
     STK_KERNEL_CASE(7)
 #endif
-    default:
-        return nullptr;
+    default: {
+        k = nullptr;
+        break; }
     }
+
+    return CastCppKernelInterfaceToC(k);
 }
 
 void stk_kernel_destroy(stk_kernel_t *k)
@@ -327,7 +379,7 @@ void stk_kernel_destroy(stk_kernel_t *k)
     // the destructor: the platform teardown inside ~IKernel() may still invoke
     // GetPlatform() paths, and we must not leave a dangling overrider pointer
     // registered at that point.
-    UnregisterKernel(reinterpret_cast<IKernel *>(k));
+    UnregisterKernel(CastCToKernelInterface(k));
 }
 
 // -----------------------------------------------------------------------------
@@ -337,21 +389,21 @@ void stk_kernel_init(stk_kernel_t *k, uint32_t tick_period_us)
 {
     STK_ASSERT(k != nullptr);
 
-    reinterpret_cast<IKernel *>(k)->Initialize(tick_period_us);
+    CastCToKernelInterface(k)->Initialize(tick_period_us);
 }
 
 void stk_kernel_start(stk_kernel_t *k)
 {
     STK_ASSERT(k != nullptr);
 
-    reinterpret_cast<IKernel *>(k)->Start();
+    CastCToKernelInterface(k)->Start();
 }
 
 stk_kernel_state_t stk_kernel_get_state(const stk_kernel_t *k)
 {
     STK_ASSERT(k != nullptr);
 
-    return static_cast<stk_kernel_state_t>(reinterpret_cast<const stk::IKernel *>(k)->GetState());
+    return static_cast<stk_kernel_state_t>(CastCToKernelInterfaceConst(k)->GetState());
 }
 
 bool stk_kernel_is_schedulable(const stk_kernel_t *k)
@@ -359,56 +411,56 @@ bool stk_kernel_is_schedulable(const stk_kernel_t *k)
     STK_ASSERT(k != nullptr);
 
     return SchedulabilityCheck::IsSchedulableWCRT<STK_C_KERNEL_MAX_TASKS>(
-        reinterpret_cast<stk::IKernel *>(const_cast<stk_kernel_t *>(k))->GetSwitchStrategy());
+        const_cast<IKernel *>(CastCToKernelInterfaceConst(k))->GetSwitchStrategy());
 }
 
-void stk_kernel_add_task(stk_kernel_t *k, stk_task_t *task)
+void stk_kernel_add_task(stk_kernel_t *k, stk_task_t *tsk)
 {
     STK_ASSERT(k != nullptr);
-    STK_ASSERT(task != nullptr);
+    STK_ASSERT(tsk != nullptr);
 
-    reinterpret_cast<IKernel *>(k)->AddTask(&task->handle);
+    CastCToKernelInterface(k)->AddTask(&tsk->handle);
 }
 
-void stk_kernel_remove_task(stk_kernel_t *k, stk_task_t *task)
+void stk_kernel_remove_task(stk_kernel_t *k, stk_task_t *tsk)
 {
     STK_ASSERT(k != nullptr);
-    STK_ASSERT(task != nullptr);
+    STK_ASSERT(tsk != nullptr);
 
-    reinterpret_cast<IKernel *>(k)->RemoveTask(&task->handle);
+    CastCToKernelInterface(k)->RemoveTask(&tsk->handle);
 }
 
 bool stk_kernel_is_started(const stk_kernel_t *k)
 {
     STK_ASSERT(k != nullptr);
 
-    const stk::IKernel::EKernelState st = reinterpret_cast<const stk::IKernel *>(k)->GetState();
+    const stk::IKernel::EKernelState st = CastCToKernelInterfaceConst(k)->GetState();
     return ((st == stk::IKernel::KSTATE_RUNNING) || (st == stk::IKernel::KSTATE_SUSPENDED));
 }
 
-void stk_kernel_schedule_task_removal(stk_kernel_t *k, stk_task_t *task)
+void stk_kernel_schedule_task_removal(stk_kernel_t *k, stk_task_t *tsk)
 {
     STK_ASSERT(k != nullptr);
-    STK_ASSERT(task != nullptr);
+    STK_ASSERT(tsk != nullptr);
 
-    reinterpret_cast<IKernel *>(k)->ScheduleTaskRemoval(&task->handle);
+    CastCToKernelInterface(k)->ScheduleTaskRemoval(&tsk->handle);
 }
 
-void stk_kernel_suspend_task(stk_kernel_t *k, stk_task_t *task, bool *suspended)
+void stk_kernel_suspend_task(stk_kernel_t *k, stk_task_t *tsk, bool *suspended)
 {
     STK_ASSERT(k != nullptr);
-    STK_ASSERT(task != nullptr);
+    STK_ASSERT(tsk != nullptr);
     STK_ASSERT(suspended != nullptr);
 
-    reinterpret_cast<IKernel *>(k)->SuspendTask(&task->handle, *suspended);
+    CastCToKernelInterface(k)->SuspendTask(&tsk->handle, *suspended);
 }
 
-void stk_kernel_resume_task(stk_kernel_t *k, stk_task_t *task)
+void stk_kernel_resume_task(stk_kernel_t *k, stk_task_t *tsk)
 {
     STK_ASSERT(k != nullptr);
-    STK_ASSERT(task != nullptr);
+    STK_ASSERT(tsk != nullptr);
 
-    reinterpret_cast<IKernel *>(k)->ResumeTask(&task->handle);
+    CastCToKernelInterface(k)->ResumeTask(&tsk->handle);
 }
 
 size_t stk_kernel_enumerate_tasks(stk_kernel_t *k, stk_task_t **tasks, size_t max_count)
@@ -423,13 +475,13 @@ size_t stk_kernel_enumerate_tasks(stk_kernel_t *k, stk_task_t **tasks, size_t ma
         static_cast<size_t>(STK_C_TASKS_MAX);
 
     // Pass via ArrayView temporary object
-    const size_t ret_count = reinterpret_cast<IKernel *>(k)->EnumerateTasks(
-        ArrayView<stk::ITask*>(itasks, requested_size));
+    const size_t ret_count = CastCToKernelInterface(k)->EnumerateTasks(
+        ArrayView<stk::ITask *>(itasks, requested_size));
 
     ArrayView<stk_task_t *> output_view(tasks, max_count);
     for (size_t i = 0U; i < ret_count; ++i)
     {
-        output_view[i] = reinterpret_cast<stk_task_t *>(itasks[i]);
+        output_view[i] = CastCppTaskInterfaceToC(itasks[i]);
     }
 
     return ret_count;
@@ -439,50 +491,48 @@ stk_timeout_t stk_kernel_suspend(stk_kernel_t *k)
 {
     STK_ASSERT(k != nullptr);
 
-    return static_cast<stk_timeout_t>(
-        reinterpret_cast<IKernel *>(k)->GetPlatform()->Suspend());
+    return static_cast<stk_timeout_t>(CastCToKernelInterface(k)->GetPlatform()->Suspend());
 }
 
 void stk_kernel_resume(stk_kernel_t *k, stk_timeout_t elapsed_ticks)
 {
     STK_ASSERT(k != nullptr);
 
-    reinterpret_cast<IKernel *>(k)->GetPlatform()->Resume(
-        static_cast<stk::Timeout>(elapsed_ticks));
+    CastCToKernelInterface(k)->GetPlatform()->Resume(static_cast<stk::Timeout>(elapsed_ticks));
 }
 
 void stk_kernel_process_tick(stk_kernel_t *k)
 {
     STK_ASSERT(k != nullptr);
 
-    reinterpret_cast<IKernel *>(k)->GetPlatform()->ProcessTick();
+    CastCToKernelInterface(k)->GetPlatform()->ProcessTick();
 }
 
 void stk_kernel_process_hard_fault(stk_kernel_t *k)
 {
     STK_ASSERT(k != nullptr);
 
-    reinterpret_cast<IKernel *>(k)->GetPlatform()->ProcessHardFault();
+    CastCToKernelInterface(k)->GetPlatform()->ProcessHardFault();
 }
 
 void stk_kernel_set_event_overrider(stk_kernel_t *k, stk_event_overrider_t *overrider)
 {
     STK_ASSERT(k != nullptr);
 
-    SetEventOverrider(reinterpret_cast<IKernel *>(k), overrider);
+    SetEventOverrider(CastCToKernelInterface(k), overrider);
 }
 
 void stk_kernel_add_task_hrt(stk_kernel_t *k,
-                             stk_task_t *task,
-                             int32_t periodicity_ticks,
-                             int32_t deadline_ticks,
-                             int32_t start_delay_ticks)
+                             stk_task_t   *tsk,
+                             int32_t       periodicity_ticks,
+                             int32_t       deadline_ticks,
+                             int32_t       start_delay_ticks)
 {
     STK_ASSERT(k != nullptr);
-    STK_ASSERT(task != nullptr);
+    STK_ASSERT(tsk != nullptr);
 
-    reinterpret_cast<IKernel *>(k)->AddTask(
-        &task->handle,
+    CastCToKernelInterface(k)->AddTask(
+        &tsk->handle,
         periodicity_ticks,
         deadline_ticks,
         start_delay_ticks);
@@ -491,71 +541,72 @@ void stk_kernel_add_task_hrt(stk_kernel_t *k,
 // -----------------------------------------------------------------------------
 // Task creation
 // -----------------------------------------------------------------------------
-stk_task_t *stk_task_create_privileged(stk_task_entry_t entry,
-                                       void *arg,
-                                       stk_word_t *stack,
-                                       uint32_t stack_size)
+stk_task_t *stk_task_create_privileged(stk_task_entry_t  entry,
+                                       void             *arg,
+                                       stk_word_t       *stack,
+                                       uint32_t          stack_size)
 {
     STK_ASSERT(entry != nullptr);
     STK_ASSERT(stack != nullptr);
     STK_ASSERT(stack_size != 0);
 
-    return reinterpret_cast<stk_task_t *>(AllocateTask(entry, arg, stack, stack_size, ACCESS_PRIVILEGED));
+    return AllocateTask(entry, arg, stack, stack_size, ACCESS_PRIVILEGED);
 }
 
-stk_task_t *stk_task_create_user(stk_task_entry_t entry,
-                                 void *arg,
-                                 stk_word_t *stack,
-                                 uint32_t stack_size)
+stk_task_t *stk_task_create_user(stk_task_entry_t  entry,
+                                 void             *arg,
+                                 stk_word_t       *stack,
+                                 uint32_t          stack_size)
 {
     STK_ASSERT(entry != nullptr);
     STK_ASSERT(stack != nullptr);
     STK_ASSERT(stack_size != 0);
 
-    return reinterpret_cast<stk_task_t *>(AllocateTask(entry, arg, stack, stack_size, ACCESS_USER));
+    return AllocateTask(entry, arg, stack, stack_size, ACCESS_USER);
 }
 
-void stk_task_set_weight(stk_task_t *task, uint32_t weight)
+void stk_task_set_weight(stk_task_t *tsk, stk_weight_t weight)
 {
-    STK_ASSERT(task != nullptr);
-    STK_ASSERT(weight != 0);
+    STK_ASSERT(tsk != nullptr);
 
-    task->handle.SetWeight(weight);
+    tsk->handle.SetWeight(weight);
 }
 
-void stk_task_set_priority(stk_task_t *task, uint8_t priority)
+void stk_task_set_priority(stk_task_t *tsk, uint8_t priority)
 {
-    STK_ASSERT(priority <= 31);
+    STK_ASSERT(priority <= 31U);
+    
+    const stk_weight_t weight = static_cast<stk_weight_t>(priority);
 
-    stk_task_set_weight(task, priority);
+    stk_task_set_weight(tsk, weight);
 }
 
-void stk_task_set_name(stk_task_t *task, const char *tname)
+void stk_task_set_name(stk_task_t *tsk, const char *tname)
 {
-    STK_ASSERT(task != nullptr);
+    STK_ASSERT(tsk != nullptr);
 
-    task->handle.SetName(tname);
+    tsk->handle.SetName(tname);
 }
 
-const char *stk_task_get_name(const stk_task_t *task)
+const char *stk_task_get_name(const stk_task_t *tsk)
 {
-    STK_ASSERT(task != nullptr);
+    STK_ASSERT(tsk != nullptr);
 
-    return task->handle.GetTraceName();
+    return tsk->handle.GetTraceName();
 }
 
-stk_tid_t stk_task_get_id(const stk_task_t *task)
+stk_tid_t stk_task_get_id(const stk_task_t *tsk)
 {
-    STK_ASSERT(task != nullptr);
+    STK_ASSERT(tsk != nullptr);
 
-    return task->handle.GetId();
+    return tsk->handle.GetId();
 }
 
-void stk_task_destroy(stk_task_t *task)
+void stk_task_destroy(stk_task_t *tsk)
 {
-    STK_ASSERT(task != nullptr);
+    STK_ASSERT(tsk != nullptr);
 
-    FreeTask(task);
+    FreeTask(tsk);
 }
 
 // -----------------------------------------------------------------------------
@@ -575,7 +626,7 @@ void        stk_delay(stk_timeout_t ticks)     { stk::Delay(ticks); }
 void        stk_sleep(stk_timeout_t ticks)     { stk::Sleep(ticks); }
 void        stk_delay_ms(stk_timeout_t ms)     { stk::DelayMs(ms); }
 void        stk_sleep_ms(stk_timeout_t ms)     { stk::SleepMs(ms); }
-void        stk_sleep_until(stk_tick_t ts)     { stk::SleepUntil(ts); }
+bool        stk_sleep_until(stk_tick_t ts)     { return stk::SleepUntil(ts); }
 void        stk_sleep_cancel(stk_tid_t tid)    { stk::SleepCancel(tid); }
 void        stk_yield(void)                    { stk::Yield(); }
 

--- a/interop/c/src/stk_c_memory.cpp
+++ b/interop/c/src/stk_c_memory.cpp
@@ -23,11 +23,11 @@ using namespace stk::memory;
 // the C++ BlockMemoryPool::AlignBlockSize() function.  Both must produce identical
 // results; if this assertion fires, update one of the two definitions.
 static_assert(
-    STK_BLOCKPOOL_ALIGN_BLOCK_SIZE(1)  == BlockMemoryPool::AlignBlockSize(1)  &&
-    STK_BLOCKPOOL_ALIGN_BLOCK_SIZE(3)  == BlockMemoryPool::AlignBlockSize(3)  &&
-    STK_BLOCKPOOL_ALIGN_BLOCK_SIZE(4)  == BlockMemoryPool::AlignBlockSize(4)  &&
-    STK_BLOCKPOOL_ALIGN_BLOCK_SIZE(7)  == BlockMemoryPool::AlignBlockSize(7)  &&
-    STK_BLOCKPOOL_ALIGN_BLOCK_SIZE(16) == BlockMemoryPool::AlignBlockSize(16),
+    STK_BLOCKPOOL_ALIGN_BLOCK_SIZE(1U)  == BlockMemoryPool::AlignBlockSize(1U)  &&
+    STK_BLOCKPOOL_ALIGN_BLOCK_SIZE(3U)  == BlockMemoryPool::AlignBlockSize(3U)  &&
+    STK_BLOCKPOOL_ALIGN_BLOCK_SIZE(4U)  == BlockMemoryPool::AlignBlockSize(4U)  &&
+    STK_BLOCKPOOL_ALIGN_BLOCK_SIZE(7U)  == BlockMemoryPool::AlignBlockSize(7U)  &&
+    STK_BLOCKPOOL_ALIGN_BLOCK_SIZE(16U) == BlockMemoryPool::AlignBlockSize(16U),
     "STK_BLOCKPOOL_ALIGN_BLOCK_SIZE and BlockMemoryPool::AlignBlockSize() have diverged. "
     "Keep both definitions in sync.");
 
@@ -75,11 +75,9 @@ static struct BlockPoolSlot
     BlockPoolSlot() : busy(false)
     {}
 
-    stk_blockpool_t       *pool()       { return reinterpret_cast<stk_blockpool_t *>(storage); }
-    const stk_blockpool_t *pool() const { return reinterpret_cast<const stk_blockpool_t *>(storage); }
+    stk_blockpool_t       *pool()       { return reinterpret_cast<stk_blockpool_t *>(reinterpret_cast<void *>(storage)); }
+    const stk_blockpool_t *pool() const { return reinterpret_cast<const stk_blockpool_t *>(reinterpret_cast<const void *>(storage)); }
 
-    // Raw storage for placement-new, keeps the slot trivially constructible
-    // while letting BlockMemoryPool's own ctor/dtor run normally.
     Word storage[StkGetWordCountForType<stk_blockpool_t>()];
     bool busy;
 }
@@ -92,31 +90,39 @@ s_BlockPools[STK_C_BLOCKPOOL_MAX];
 // Find the slot that owns 'pool'; returns nullptr if not found.
 static BlockPoolSlot *FindSlot(const stk_blockpool_t *pool)
 {
+    BlockPoolSlot *result = nullptr;
+
     for (size_t i = 0U; i < STK_C_BLOCKPOOL_MAX; ++i)
     {
         if (s_BlockPools[i].busy)
         {
             if (s_BlockPools[i].pool() == pool)
-                return &s_BlockPools[i];
+            {
+                result = &s_BlockPools[i];
+                break;
+            }
         }
     }
-    
-    return nullptr;
+
+    return result;
 }
 
 // Acquire a free slot; returns nullptr when the pool is exhausted.
 static BlockPoolSlot *AcquireSlot()
 {
+    BlockPoolSlot *result = nullptr;
+
     for (size_t i = 0U; i < STK_C_BLOCKPOOL_MAX; ++i)
     {
         if (!s_BlockPools[i].busy)
         {
             s_BlockPools[i].busy = true;
-            return &s_BlockPools[i];
+            result = &s_BlockPools[i];
+            break;
         }
     }
-    
-    return nullptr;
+
+    return result;
 }
 
 // =============================================================================
@@ -135,58 +141,64 @@ stk_blockpool_t *stk_blockpool_create(size_t capacity, size_t raw_block_size, co
 
     const sync::ScopedCriticalSection cs_;
 
-    BlockPoolSlot *slot = AcquireSlot();
-    if (slot == nullptr)
+    BlockPoolSlot *const slot = AcquireSlot();
+
+    // pool exhausted — increase STK_C_BLOCKPOOL_MAX
+    STK_ASSERT(slot != nullptr);
+
+    stk_blockpool_t *result = nullptr;
+    if (slot != nullptr)
     {
-        // pool exhausted — increase STK_C_BLOCKPOOL_MAX
-        STK_ASSERT(false);
-        return nullptr;
+        result = new (slot->storage) stk_blockpool_t(capacity, raw_block_size, name);
     }
 
-    return new (slot->storage) stk_blockpool_t(capacity, raw_block_size, name);
+    return result;
 }
 
 stk_blockpool_t *stk_blockpool_create_static(size_t      capacity,
                                              size_t      raw_block_size,
-                                             uint8_t    *storage,
+                                             uint8_t    *storage_ptr,
                                              size_t      storage_size,
                                              const char *name)
 {
     STK_ASSERT(capacity > 0U);
     STK_ASSERT(raw_block_size > 0U);
-    STK_ASSERT(storage != nullptr);
+    STK_ASSERT(storage_ptr != nullptr);
     STK_ASSERT(storage_size >= (capacity * BlockMemoryPool::AlignBlockSize(raw_block_size)));
 
-    sync::ScopedCriticalSection cs_;
+    const sync::ScopedCriticalSection cs_;
 
-    BlockPoolSlot *slot = AcquireSlot();
-    if (slot == nullptr)
+    BlockPoolSlot *const slot = AcquireSlot();
+
+    // pool exhausted — increase STK_C_BLOCKPOOL_MAX
+    STK_ASSERT(slot != nullptr);
+
+    stk_blockpool_t *result = nullptr;
+    if (slot != nullptr)
     {
-        // pool exhausted — increase STK_C_BLOCKPOOL_MAX
-        STK_ASSERT(false);
-        return nullptr;
+        result = new (slot->storage) stk_blockpool_t(capacity, raw_block_size,
+                                                     storage_ptr, storage_size, name);
     }
 
-    return new (slot->storage) stk_blockpool_t(capacity, raw_block_size,
-                                               storage, storage_size, name);
+    return result;
 }
 
 void stk_blockpool_destroy(stk_blockpool_t *pool)
 {
     STK_ASSERT(pool != nullptr);
 
-    sync::ScopedCriticalSection cs_;
+    const sync::ScopedCriticalSection cs_;
 
-    BlockPoolSlot *slot = FindSlot(pool);
+    BlockPoolSlot *const slot = FindSlot(pool);
 
     // pool not found: double-destroy or corruption
     STK_ASSERT(slot != nullptr);
-    if (slot == nullptr)
-        return;
-
-    // Explicitly run the destructor (frees heap storage if owned).
-    pool->~stk_blockpool_t();
-    slot->busy = false;
+    if (slot != nullptr)
+    {
+        // Explicitly run the destructor (frees heap storage if owned).
+        pool->~stk_blockpool_t();
+        slot->busy = false;
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -203,11 +215,11 @@ void *stk_blockpool_alloc(stk_blockpool_t *pool)
     return pool->handle.Alloc();
 }
 
-void *stk_blockpool_timed_alloc(stk_blockpool_t *pool, uint32_t timeout)
+void *stk_blockpool_timed_alloc(stk_blockpool_t *pool, stk_timeout_t timeout)
 {
     STK_ASSERT(pool != nullptr);
 
-    return pool->handle.TimedAlloc(static_cast<Timeout>(timeout));
+    return pool->handle.TimedAlloc(timeout);
 }
 
 void *stk_blockpool_try_alloc(stk_blockpool_t *pool)

--- a/interop/c/src/stk_c_sync.cpp
+++ b/interop/c/src/stk_c_sync.cpp
@@ -32,46 +32,52 @@ struct stk_mutex_t
     Mutex handle;
 };
 
-stk_mutex_t *stk_mutex_create(stk_mutex_mem_t *memory, uint32_t memory_size)
+stk_mutex_t *stk_mutex_create(stk_mutex_mem_t *const membuf, uint32_t membuf_size)
 {
-    STK_ASSERT(memory != nullptr);
-    STK_ASSERT(memory_size >= sizeof(stk_mutex_t));
-    if (memory_size < sizeof(stk_mutex_t))
-        return nullptr;
+    STK_ASSERT(membuf != nullptr);
+    STK_ASSERT(membuf_size >= sizeof(stk_mutex_t));
 
-    return new (memory->data) stk_mutex_t();
+    stk_mutex_t *result = nullptr;
+    if (membuf_size >= sizeof(stk_mutex_t))
+    {
+        result = new (membuf->data) stk_mutex_t();
+    }
+
+    return result;
 }
 
 void stk_mutex_destroy(stk_mutex_t *mtx)
 {
-    if (mtx != NULL)
+    if (mtx != nullptr)
+    {
         mtx->~stk_mutex_t();
+    }
 }
 
 void stk_mutex_lock(stk_mutex_t *mtx)
 {
-    STK_ASSERT(mtx != NULL);
+    STK_ASSERT(mtx != nullptr);
 
     mtx->handle.Lock();
 }
 
 bool stk_mutex_trylock(stk_mutex_t *mtx)
 {
-    STK_ASSERT(mtx != NULL);
+    STK_ASSERT(mtx != nullptr);
 
     return mtx->handle.TryLock();
 }
 
 void stk_mutex_unlock(stk_mutex_t *mtx)
 {
-    STK_ASSERT(mtx != NULL);
+    STK_ASSERT(mtx != nullptr);
 
     mtx->handle.Unlock();
 }
 
 bool stk_mutex_timed_lock(stk_mutex_t *mtx, stk_timeout_t timeout)
 {
-    STK_ASSERT(mtx != NULL);
+    STK_ASSERT(mtx != nullptr);
 
     return mtx->handle.TimedLock(timeout);
 }
@@ -84,38 +90,44 @@ struct stk_spinlock_t
     sync::SpinLock handle;
 };
 
-stk_spinlock_t *stk_spinlock_create(stk_spinlock_mem_t *memory, uint32_t memory_size)
+stk_spinlock_t *stk_spinlock_create(stk_spinlock_mem_t *const membuf, uint32_t membuf_size)
 {
-    STK_ASSERT(memory != nullptr);
-    STK_ASSERT(memory_size >= sizeof(stk_spinlock_t));
-    if (memory_size < sizeof(stk_spinlock_t))
-        return nullptr;
+    STK_ASSERT(membuf != nullptr);
+    STK_ASSERT(membuf_size >= sizeof(stk_spinlock_t));
 
-    return new (memory->data) stk_spinlock_t();
+    stk_spinlock_t *result = nullptr;
+    if (membuf_size >= sizeof(stk_spinlock_t))
+    {
+        result = new (membuf->data) stk_spinlock_t();
+    }
+
+    return result;
 }
 
-void stk_spinlock_destroy(stk_spinlock_t *lock)
+void stk_spinlock_destroy(stk_spinlock_t *slock)
 {
-    if (lock != nullptr)
-        lock->~stk_spinlock_t();
+    if (slock != nullptr)
+    {
+        slock->~stk_spinlock_t();
+    }
 }
 
-void stk_spinlock_lock(stk_spinlock_t *lock)
+void stk_spinlock_lock(stk_spinlock_t *slock)
 {
-    STK_ASSERT(lock != nullptr);
-    lock->handle.Lock();
+    STK_ASSERT(slock != nullptr);
+    slock->handle.Lock();
 }
 
-bool stk_spinlock_trylock(stk_spinlock_t *lock)
+bool stk_spinlock_trylock(stk_spinlock_t *slock)
 {
-    STK_ASSERT(lock != nullptr);
-    return lock->handle.TryLock();
+    STK_ASSERT(slock != nullptr);
+    return slock->handle.TryLock();
 }
 
-void stk_spinlock_unlock(stk_spinlock_t *lock)
+void stk_spinlock_unlock(stk_spinlock_t *slock)
 {
-    STK_ASSERT(lock != nullptr);
-    lock->handle.Unlock();
+    STK_ASSERT(slock != nullptr);
+    slock->handle.Unlock();
 }
 
 // -----------------------------------------------------------------------------
@@ -126,20 +138,26 @@ struct stk_cv_t
     ConditionVariable handle;
 };
 
-stk_cv_t *stk_cv_create(stk_cv_mem_t *memory, uint32_t memory_size)
+stk_cv_t *stk_cv_create(stk_cv_mem_t *const membuf, uint32_t membuf_size)
 {
-    STK_ASSERT(memory != nullptr);
-    STK_ASSERT(memory_size >= sizeof(stk_cv_t));
-    if (memory_size < sizeof(stk_cv_t))
-        return nullptr;
+    STK_ASSERT(membuf != nullptr);
+    STK_ASSERT(membuf_size >= sizeof(stk_cv_t));
 
-    return new (memory->data) stk_cv_t();
+    stk_cv_t *result = nullptr;
+    if (membuf_size >= sizeof(stk_cv_t))
+    {
+        result = new (membuf->data) stk_cv_t();
+    }
+
+    return result;
 }
 
 void stk_cv_destroy(stk_cv_t *cv)
 {
     if (cv != nullptr)
+    {
         cv->~stk_cv_t();
+    }
 }
 
 bool stk_cv_wait(stk_cv_t *cv, stk_mutex_t *mtx, stk_timeout_t timeout)
@@ -175,20 +193,28 @@ struct stk_event_t
     Event handle;
 };
 
-stk_event_t *stk_event_create(stk_event_mem_t *memory, uint32_t memory_size, bool manual_reset)
+stk_event_t *stk_event_create(stk_event_mem_t *const membuf, 
+                              uint32_t         membuf_size, 
+                              bool             manual_reset)
 {
-    STK_ASSERT(memory != nullptr);
-    STK_ASSERT(memory_size >= sizeof(stk_event_t));
-    if (memory_size < sizeof(stk_event_t))
-        return nullptr;
+    STK_ASSERT(membuf != nullptr);
+    STK_ASSERT(membuf_size >= sizeof(stk_event_t));
 
-    return new (memory->data) stk_event_t(manual_reset);
+    stk_event_t *result = nullptr;
+    if (membuf_size >= sizeof(stk_event_t))
+    {
+        result = new (membuf->data) stk_event_t(manual_reset);
+    }
+
+    return result;
 }
 
 void stk_event_destroy(stk_event_t *ev)
 {
     if (ev != nullptr)
+    {
         ev->~stk_event_t();
+    }
 }
 
 bool stk_event_wait(stk_event_t *ev, stk_timeout_t timeout)
@@ -205,18 +231,18 @@ bool stk_event_trywait(stk_event_t *ev)
     return ev->handle.TryWait();
 }
 
-void stk_event_set(stk_event_t *ev)
+bool stk_event_set(stk_event_t *ev)
 {
     STK_ASSERT(ev != nullptr);
 
-    ev->handle.Set();
+    return ev->handle.Set();
 }
 
-void stk_event_reset(stk_event_t *ev)
+bool stk_event_reset(stk_event_t *ev)
 {
     STK_ASSERT(ev != nullptr);
 
-    ev->handle.Reset();
+    return ev->handle.Reset();
 }
 
 void stk_event_pulse(stk_event_t *ev)
@@ -239,25 +265,31 @@ struct stk_sem_t
     Semaphore handle;
 };
 
-stk_sem_t *stk_sem_create(stk_sem_mem_t *memory, uint32_t memory_size,
-                           uint32_t initial_count, uint32_t max_count)
+stk_sem_t *stk_sem_create(stk_sem_mem_t *const membuf, 
+                          uint32_t       membuf_size,
+                          uint32_t       initial_count, 
+                          uint32_t       max_count)
 {
-    STK_ASSERT(memory != nullptr);
-    STK_ASSERT(memory_size >= sizeof(stk_sem_t));
+    STK_ASSERT(membuf != nullptr);
+    STK_ASSERT(membuf_size >= sizeof(stk_sem_t));
     STK_ASSERT(initial_count < (max_count == 0U ? Semaphore::COUNT_MAX : max_count));
 
-    if (memory_size < sizeof(stk_sem_t))
-        return nullptr;
+    stk_sem_t *result = nullptr;
+    if (membuf_size >= sizeof(stk_sem_t))
+    {
+        const uint32_t effective_max = ((max_count == 0U) ? Semaphore::COUNT_MAX : max_count);
+        result = new (membuf->data) stk_sem_t(initial_count, effective_max);
+    }
 
-    const uint32_t effective_max = (max_count == 0U) ? Semaphore::COUNT_MAX : max_count;
-
-    return new (memory->data) stk_sem_t(initial_count, effective_max);
+    return result;
 }
 
 void stk_sem_destroy(stk_sem_t *sem)
 {
     if (sem != nullptr)
+    {
         sem->~stk_sem_t();
+    }
 }
 
 bool stk_sem_wait(stk_sem_t *sem, stk_timeout_t timeout)
@@ -299,20 +331,28 @@ struct stk_ef_t
     EventFlags handle;
 };
 
-stk_ef_t *stk_ef_create(stk_ef_mem_t *memory, uint32_t memory_size, uint32_t initial_flags)
+stk_ef_t *stk_ef_create(stk_ef_mem_t *const membuf, 
+                        uint32_t      membuf_size, 
+                        uint32_t      initial_flags)
 {
-    STK_ASSERT(memory != nullptr);
-    STK_ASSERT(memory_size >= sizeof(stk_ef_t));
-    if (memory_size < sizeof(stk_ef_t))
-        return nullptr;
+    STK_ASSERT(membuf != nullptr);
+    STK_ASSERT(membuf_size >= sizeof(stk_ef_t));
 
-    return new (memory->data) stk_ef_t(initial_flags);
+    stk_ef_t *result = nullptr;
+    if (membuf_size >= sizeof(stk_ef_t))
+    {
+        result = new (membuf->data) stk_ef_t(initial_flags);
+    }
+
+    return result;
 }
 
 void stk_ef_destroy(stk_ef_t *ef)
 {
     if (ef != nullptr)
+    {
         ef->~stk_ef_t();
+    }
 }
 
 uint32_t stk_ef_set(stk_ef_t *ef, uint32_t flags)
@@ -362,30 +402,35 @@ struct stk_pipe_t
     {}
 };
 
-stk_pipe_t *stk_pipe_create(stk_pipe_mem_t *memory,
-                             uint32_t       memory_size,
-                             uint8_t       *buf,
-                             uint32_t       buf_size,
-                             size_t         capacity,
-                             size_t         element_size)
+stk_pipe_t *stk_pipe_create(stk_pipe_mem_t *const membuf,
+                            uint32_t        membuf_size,
+                            uint8_t        *buf,
+                            uint32_t        buf_size,
+                            size_t          capacity,
+                            size_t          element_size)
 {
-    STK_ASSERT(memory       != nullptr);
+    STK_ASSERT(membuf       != nullptr);
     STK_ASSERT(buf          != nullptr);
     STK_ASSERT(capacity     >= 1U);
     STK_ASSERT(element_size >= 1U);
-    STK_ASSERT(memory_size  >= sizeof(stk_pipe_t));
+    STK_ASSERT(membuf_size  >= sizeof(stk_pipe_t));
     STK_ASSERT(buf_size     >= capacity * element_size);
 
-    if ((memory_size < sizeof(stk_pipe_t)) || (buf_size < (capacity * element_size)))
-        return nullptr;
+    stk_pipe_t *result = nullptr;
+    if ((membuf_size >= sizeof(stk_pipe_t)) && (buf_size >= (capacity * element_size)))
+    {
+        result = new (membuf->data) stk_pipe_t(buf, capacity, element_size);
+    }
 
-    return new (memory->data) stk_pipe_t(buf, capacity, element_size);
+    return result;
 }
 
 void stk_pipe_destroy(stk_pipe_t *pipe)
 {
     if (pipe != nullptr)
+    {
         pipe->~stk_pipe_t();
+    }
 }
 
 bool stk_pipe_write(stk_pipe_t *pipe, const void *data, stk_timeout_t timeout)
@@ -448,8 +493,11 @@ size_t stk_pipe_tryread_bulk(stk_pipe_t *pipe, void *dst, size_t count)
     return pipe->handle.TryReadBulk(dst, count);
 }
 
-size_t stk_pipe_read_bulk_triggered(stk_pipe_t *pipe, void *dst,
-                                    size_t trigger, size_t max_count, stk_timeout_t timeout)
+size_t stk_pipe_read_bulk_triggered(stk_pipe_t   *pipe, 
+                                    void         *dst,
+                                    size_t        trigger, 
+                                    size_t        max_count, 
+                                    stk_timeout_t timeout)
 {
     STK_ASSERT(pipe != nullptr);
 
@@ -531,30 +579,35 @@ struct stk_msgq_t
     MessageQueue handle;
 };
 
-stk_msgq_t *stk_msgq_create(stk_msgq_mem_t *memory,
-                             uint32_t        memory_size,
-                             uint8_t        *buf,
-                             uint32_t        buf_size,
-                             size_t          capacity,
-                             size_t          msg_size)
+stk_msgq_t *stk_msgq_create(stk_msgq_mem_t *const membuf,
+                            uint32_t        membuf_size,
+                            uint8_t        *buf,
+                            uint32_t        buf_size,
+                            size_t          capacity,
+                            size_t          msg_size)
 {
-    STK_ASSERT(memory != nullptr);
+    STK_ASSERT(membuf != nullptr);
     STK_ASSERT(buf != nullptr);
     STK_ASSERT(capacity >= 1U);
     STK_ASSERT(msg_size >= 1U);
-    STK_ASSERT(memory_size >= sizeof(stk_msgq_t));
+    STK_ASSERT(membuf_size >= sizeof(stk_msgq_t));
     STK_ASSERT(buf_size >= capacity * msg_size);
 
-    if ((memory_size < sizeof(stk_msgq_t)) || (buf_size < (capacity * msg_size)))
-        return nullptr;
+    stk_msgq_t *result = nullptr;
+    if ((membuf_size >= sizeof(stk_msgq_t)) && (buf_size >= (capacity * msg_size)))
+    {
+        result = new (membuf) stk_msgq_t(buf, capacity, msg_size);
+    }
 
-    return new (memory) stk_msgq_t(buf, capacity, msg_size);
+    return result;
 }
 
 void stk_msgq_destroy(stk_msgq_t *mq)
 {
     if (mq != nullptr)
+    {
         mq->~stk_msgq_t();
+    }
 }
 
 bool stk_msgq_put(stk_msgq_t *mq, const void *msg, stk_timeout_t timeout)
@@ -562,7 +615,7 @@ bool stk_msgq_put(stk_msgq_t *mq, const void *msg, stk_timeout_t timeout)
     STK_ASSERT(mq != nullptr);
     STK_ASSERT(msg != nullptr);
 
-    return reinterpret_cast<stk_msgq_t *>(mq)->handle.Put(msg, timeout);
+    return mq->handle.Put(msg, timeout);
 }
 
 bool stk_msgq_tryput(stk_msgq_t *mq, const void *msg)
@@ -570,7 +623,7 @@ bool stk_msgq_tryput(stk_msgq_t *mq, const void *msg)
     STK_ASSERT(mq != nullptr);
     STK_ASSERT(msg != nullptr);
 
-    return reinterpret_cast<stk_msgq_t *>(mq)->handle.TryPut(msg);
+    return mq->handle.TryPut(msg);
 }
 
 bool stk_msgq_putfront(stk_msgq_t *mq, const void *msg, stk_timeout_t timeout)
@@ -578,7 +631,7 @@ bool stk_msgq_putfront(stk_msgq_t *mq, const void *msg, stk_timeout_t timeout)
     STK_ASSERT(mq != nullptr);
     STK_ASSERT(msg != nullptr);
 
-    return reinterpret_cast<stk_msgq_t *>(mq)->handle.PutFront(msg, timeout);
+    return mq->handle.PutFront(msg, timeout);
 }
 
 bool stk_msgq_tryputfront(stk_msgq_t *mq, const void *msg)
@@ -586,7 +639,7 @@ bool stk_msgq_tryputfront(stk_msgq_t *mq, const void *msg)
     STK_ASSERT(mq != nullptr);
     STK_ASSERT(msg != nullptr);
 
-    return reinterpret_cast<stk_msgq_t *>(mq)->handle.TryPutFront(msg);
+    return mq->handle.TryPutFront(msg);
 }
 
 bool stk_msgq_get(stk_msgq_t *mq, void *msg, stk_timeout_t timeout)
@@ -594,7 +647,7 @@ bool stk_msgq_get(stk_msgq_t *mq, void *msg, stk_timeout_t timeout)
     STK_ASSERT(mq != nullptr);
     STK_ASSERT(msg != nullptr);
 
-    return reinterpret_cast<stk_msgq_t *>(mq)->handle.Get(msg, timeout);
+    return mq->handle.Get(msg, timeout);
 }
 
 bool stk_msgq_tryget(stk_msgq_t *mq, void *msg)
@@ -602,7 +655,7 @@ bool stk_msgq_tryget(stk_msgq_t *mq, void *msg)
     STK_ASSERT(mq != nullptr);
     STK_ASSERT(msg != nullptr);
 
-    return reinterpret_cast<stk_msgq_t *>(mq)->handle.TryGet(msg);
+    return mq->handle.TryGet(msg);
 }
 
 bool stk_msgq_peek(stk_msgq_t *mq, void *msg, stk_timeout_t timeout)
@@ -610,7 +663,7 @@ bool stk_msgq_peek(stk_msgq_t *mq, void *msg, stk_timeout_t timeout)
     STK_ASSERT(mq != nullptr);
     STK_ASSERT(msg != nullptr);
 
-    return reinterpret_cast<stk_msgq_t *>(mq)->handle.Peek(msg, timeout);
+    return mq->handle.Peek(msg, timeout);
 }
 
 bool stk_msgq_trypeek(stk_msgq_t *mq, void *msg)
@@ -618,7 +671,7 @@ bool stk_msgq_trypeek(stk_msgq_t *mq, void *msg)
     STK_ASSERT(mq != nullptr);
     STK_ASSERT(msg != nullptr);
 
-    return reinterpret_cast<stk_msgq_t *>(mq)->handle.TryPeek(msg);
+    return mq->handle.TryPeek(msg);
 }
 
 bool stk_msgq_peekfront(stk_msgq_t *mq, void *msg, stk_timeout_t timeout)
@@ -626,7 +679,7 @@ bool stk_msgq_peekfront(stk_msgq_t *mq, void *msg, stk_timeout_t timeout)
     STK_ASSERT(mq != nullptr);
     STK_ASSERT(msg != nullptr);
 
-    return reinterpret_cast<stk_msgq_t *>(mq)->handle.PeekFront(msg, timeout);
+    return mq->handle.PeekFront(msg, timeout);
 }
 
 bool stk_msgq_trypeekfront(stk_msgq_t *mq, void *msg)
@@ -634,70 +687,70 @@ bool stk_msgq_trypeekfront(stk_msgq_t *mq, void *msg)
     STK_ASSERT(mq != nullptr);
     STK_ASSERT(msg != nullptr);
 
-    return reinterpret_cast<stk_msgq_t *>(mq)->handle.TryPeekFront(msg);
+    return mq->handle.TryPeekFront(msg);
 }
 
 void stk_msgq_reset(stk_msgq_t *mq)
 {
     STK_ASSERT(mq != nullptr);
 
-    reinterpret_cast<stk_msgq_t *>(mq)->handle.Reset();
+    mq->handle.Reset();
 }
 
 size_t stk_msgq_get_capacity(const stk_msgq_t *mq)
 {
     STK_ASSERT(mq != nullptr);
 
-    return reinterpret_cast<const stk_msgq_t *>(mq)->handle.GetCapacity();
+    return mq->handle.GetCapacity();
 }
 
 size_t stk_msgq_get_msg_size(const stk_msgq_t *mq)
 {
     STK_ASSERT(mq != nullptr);
 
-    return reinterpret_cast<const stk_msgq_t *>(mq)->handle.GetMsgSize();
+    return mq->handle.GetMsgSize();
 }
 
 size_t stk_msgq_get_count(const stk_msgq_t *mq)
 {
     STK_ASSERT(mq != nullptr);
 
-    return reinterpret_cast<const stk_msgq_t *>(mq)->handle.GetCount();
+    return mq->handle.GetCount();
 }
 
 size_t stk_msgq_get_space(const stk_msgq_t *mq)
 {
     STK_ASSERT(mq != nullptr);
 
-    return reinterpret_cast<const stk_msgq_t *>(mq)->handle.GetSpace();
+    return mq->handle.GetSpace();
 }
 
 bool stk_msgq_is_empty(const stk_msgq_t *mq)
 {
     STK_ASSERT(mq != nullptr);
 
-    return reinterpret_cast<const stk_msgq_t *>(mq)->handle.IsEmpty();
+    return mq->handle.IsEmpty();
 }
 
 bool stk_msgq_is_full(const stk_msgq_t *mq)
 {
     STK_ASSERT(mq != nullptr);
 
-    return reinterpret_cast<const stk_msgq_t *>(mq)->handle.IsFull();
+    return mq->handle.IsFull();
 }
 
 uint8_t *stk_msgq_get_buffer(stk_msgq_t *mq)
 {
     STK_ASSERT(mq != nullptr);
 
-    return reinterpret_cast<stk_msgq_t *>(mq)->handle.GetBuffer();
+    return mq->handle.GetBuffer();
 }
 
 bool stk_msgq_is_storage_valid(const stk_msgq_t *mq)
 {
     STK_ASSERT(mq != nullptr);
 
-    return reinterpret_cast<const stk_msgq_t *>(mq)->handle.IsStorageValid();
+    return mq->handle.IsStorageValid();
 }
 
 // -----------------------------------------------------------------------------
@@ -708,20 +761,26 @@ struct stk_rwmutex_t
     sync::RWMutex handle;
 };
 
-stk_rwmutex_t *stk_rwmutex_create(stk_rwmutex_mem_t *memory, uint32_t memory_size)
+stk_rwmutex_t *stk_rwmutex_create(stk_rwmutex_mem_t *const membuf, uint32_t membuf_size)
 {
-    STK_ASSERT(memory != nullptr);
-    STK_ASSERT(memory_size >= sizeof(stk_rwmutex_t));
-    if (memory_size < sizeof(stk_rwmutex_t))
-        return nullptr;
+    STK_ASSERT(membuf != nullptr);
+    STK_ASSERT(membuf_size >= sizeof(stk_rwmutex_t));
 
-    return (stk_rwmutex_t *)new (memory->data) stk_rwmutex_t();
+    stk_rwmutex_t *result = nullptr;
+    if (membuf_size >= sizeof(stk_rwmutex_t))
+    {
+        result = new (membuf->data) stk_rwmutex_t();
+    }
+    
+    return result;
 }
 
 void stk_rwmutex_destroy(stk_rwmutex_t *rw)
 {
     if (rw != nullptr)
+    {
         rw->~stk_rwmutex_t();
+    }
 }
 
 void stk_rwmutex_read_lock(stk_rwmutex_t *rw)

--- a/interop/c/src/stk_c_time.cpp
+++ b/interop/c/src/stk_c_time.cpp
@@ -38,7 +38,7 @@ public:
     CTimerWrapper() : m_host_handle(nullptr), m_callback(nullptr), m_user_data(nullptr)
     {}
 
-    void Initialize(stk_timer_callback_t callback, void *user_data)
+    void Initialize(stk_timer_callback_t const callback, void *user_data)
     {
         STK_ASSERT(callback != nullptr);
 
@@ -60,14 +60,10 @@ public:
     }
 
     stk_timer_callback_t GetCallback() { return m_callback; }
-    void *GetUserData() { return m_user_data; }
-    stk_timerhost_t *GetHostHandle() { return m_host_handle; }
+    void *GetUserData()                { return m_user_data; }
+    stk_timerhost_t *GetHostHandle()   { return m_host_handle; }
 
-    void OnExpired(TimerHost */*host*/) override
-    {
-        if (m_callback != nullptr)
-            m_callback(m_host_handle, reinterpret_cast<stk_timer_t *>(this), m_user_data);
-    }
+    void OnExpired(TimerHost *host) override;
 
 private:
     stk_timerhost_t     *m_host_handle; //!< C-level host, forwarded to the callback
@@ -75,14 +71,37 @@ private:
     void                *m_user_data;
 };
 
-// -----------------------------------------------------------------------------
-// Timer slot pool
-// -----------------------------------------------------------------------------
 struct stk_timer_t
 {
     CTimerWrapper handle;
 };
 
+// Cast from CTimerWrapper to stk_timer_t without a warning.
+static __stk_forceinline stk_timer_t *CastCppTimerWrapperToC(CTimerWrapper *const t)
+{
+    return reinterpret_cast<stk_timer_t *>(reinterpret_cast<void *>(t));
+}
+
+// Interop-private helpers
+namespace stk {
+namespace interop_c_helper {
+
+extern void InitializeTimerHost(stk_kernel_t *kernel, stk::time::TimerHost *th, EAccessMode amode);
+
+} // interop_c_helper
+} // stk
+
+void CTimerWrapper::OnExpired(TimerHost *host)
+{
+    if (m_callback != nullptr)
+    {
+        m_callback(m_host_handle, CastCppTimerWrapperToC(this), m_user_data);
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Timer slot pool
+// -----------------------------------------------------------------------------
 static struct TimerSlot
 {
     TimerSlot() : timer(), busy(false)
@@ -119,10 +138,14 @@ extern "C" {
 
 stk_timerhost_t *stk_timerhost_get(uint8_t core_nr)
 {
-    if (core_nr >= STK_C_CPU_COUNT)
-        return nullptr;
+    stk_timerhost_t *result = nullptr;
 
-    return &s_TimerHosts[core_nr];
+    if (core_nr < STK_C_CPU_COUNT)
+    {
+        result = &s_TimerHosts[core_nr];
+    }
+
+    return result;
 }
 
 void stk_timerhost_init(stk_timerhost_t *host,
@@ -131,11 +154,11 @@ void stk_timerhost_init(stk_timerhost_t *host,
 {
     STK_ASSERT(host   != nullptr);
     STK_ASSERT(kernel != nullptr);
-
-    host->handle.Initialize(reinterpret_cast<IKernel *>(kernel),
+    
+    interop_c_helper::InitializeTimerHost(kernel, &host->handle, 
         (privileged ? ACCESS_PRIVILEGED : ACCESS_USER));
 }
-
+    
 bool stk_timerhost_shutdown(stk_timerhost_t *host)
 {
     STK_ASSERT(host != nullptr);
@@ -161,7 +184,7 @@ int64_t stk_timerhost_get_time_now(const stk_timerhost_t *host)
 {
     STK_ASSERT(host != nullptr);
 
-    return (int64_t)host->handle.GetTimeNow();
+    return static_cast<int64_t>(host->handle.GetTimeNow());
 }
 
 // -----------------------------------------------------------------------------
@@ -172,45 +195,50 @@ stk_timer_t *stk_timer_create(stk_timer_callback_t callback, void *user_data)
 {
     STK_ASSERT(callback != nullptr);
 
-    sync::ScopedCriticalSection __cs;
+    const sync::ScopedCriticalSection __cs;
 
-    for (uint32_t i = 0; i < STK_C_TIMERS_TOTAL; ++i)
+    stk_timer_t *result = nullptr;
+
+    for (uint32_t i = 0U; i < STK_C_TIMERS_TOTAL; ++i)
     {
         if (!s_Timers[i].busy)
         {
             s_Timers[i].busy = true;
             s_Timers[i].timer.handle.Initialize(callback, user_data);
-
-            return &s_Timers[i].timer;
+            result = &s_Timers[i].timer;
+            break;
         }
     }
 
     // pool exhausted, you must increase STK_C_TIMER_MAX
-    STK_ASSERT(false);
-    return nullptr;
+    STK_ASSERT(result != nullptr);
+
+    return result;
 }
 
-void stk_timer_destroy(stk_timer_t *timer)
+void stk_timer_destroy(stk_timer_t *tmr)
 {
-    STK_ASSERT(timer != nullptr);
+    STK_ASSERT(tmr != nullptr);
 
     // destroying an active timer is a programming error
-    STK_ASSERT(!timer->handle.IsActive());
+    STK_ASSERT(!tmr->handle.IsActive());
 
-    sync::ScopedCriticalSection __cs;
+    const sync::ScopedCriticalSection __cs;
 
-    for (uint32_t i = 0; i < STK_C_TIMERS_TOTAL; ++i)
+    bool found = false;
+
+    for (uint32_t i = 0U; ((i < STK_C_TIMERS_TOTAL) && !found); ++i)
     {
-        if (s_Timers[i].busy && (&s_Timers[i].timer == timer))
+        if (s_Timers[i].busy && (&s_Timers[i].timer == tmr))
         {
-            timer->handle.Reset();
+            tmr->handle.Reset();
             s_Timers[i].busy = false;
-            return;
+            found = true;
         }
     }
 
     // timer not found in the pool: indicates a double-free or corruption
-    STK_ASSERT(false);
+    STK_ASSERT(found);
 }
 
 // -----------------------------------------------------------------------------
@@ -221,102 +249,102 @@ void stk_timer_destroy(stk_timer_t *timer)
 // -----------------------------------------------------------------------------
 
 bool stk_timer_start(stk_timerhost_t *host,
-                     stk_timer_t     *timer,
+                     stk_timer_t     *tmr,
                      uint32_t         delay,
                      uint32_t         period)
 {
     STK_ASSERT(host  != nullptr);
-    STK_ASSERT(timer != nullptr);
+    STK_ASSERT(tmr != nullptr);
 
     // refresh host association before timer can fire
-    timer->handle.SetHostHandle(host);
+    tmr->handle.SetHostHandle(host);
 
-    return host->handle.Start(timer->handle, delay, period);
+    return host->handle.Start(tmr->handle, delay, period);
 }
 
-bool stk_timer_stop(stk_timerhost_t *host, stk_timer_t *timer)
+bool stk_timer_stop(stk_timerhost_t *host, stk_timer_t *tmr)
 {
     STK_ASSERT(host != nullptr);
-    STK_ASSERT(timer != nullptr);
+    STK_ASSERT(tmr != nullptr);
 
-    return host->handle.Stop(timer->handle);
+    return host->handle.Stop(tmr->handle);
 }
 
-bool stk_timer_reset(stk_timerhost_t *host, stk_timer_t *timer)
+bool stk_timer_reset(stk_timerhost_t *host, stk_timer_t *tmr)
 {
     STK_ASSERT(host != nullptr);
-    STK_ASSERT(timer != nullptr);
+    STK_ASSERT(tmr != nullptr);
 
-    return host->handle.Reset(timer->handle);
+    return host->handle.Reset(tmr->handle);
 }
 
-bool stk_timer_restart(stk_timerhost_t *host, stk_timer_t *timer, uint32_t delay, uint32_t period)
+bool stk_timer_restart(stk_timerhost_t *host, stk_timer_t *tmr, uint32_t delay, uint32_t period)
 {
     STK_ASSERT(host != nullptr);
-    STK_ASSERT(timer != nullptr);
+    STK_ASSERT(tmr != nullptr);
 
     // refresh host association before timer can fire
-    timer->handle.SetHostHandle(host);
+    tmr->handle.SetHostHandle(host);
 
-    return host->handle.Restart(timer->handle, delay, period);
+    return host->handle.Restart(tmr->handle, delay, period);
 }
 
-bool stk_timer_start_or_reset(stk_timerhost_t *host, stk_timer_t *timer, uint32_t delay, uint32_t period)
+bool stk_timer_start_or_reset(stk_timerhost_t *host, stk_timer_t *tmr, uint32_t delay, uint32_t period_ticks)
 {
     STK_ASSERT(host != nullptr);
-    STK_ASSERT(timer != nullptr);
+    STK_ASSERT(tmr != nullptr);
 
     // refresh host association (harmless if timer is already active on host)
-    timer->handle.SetHostHandle(host);
+    tmr->handle.SetHostHandle(host);
 
-    return host->handle.StartOrReset(timer->handle, delay, period);
+    return host->handle.StartOrReset(tmr->handle, delay, period_ticks);
 }
 
-bool stk_timer_set_period(stk_timerhost_t *host, stk_timer_t *timer, uint32_t period)
+bool stk_timer_set_period(stk_timerhost_t *host, stk_timer_t *tmr, uint32_t period_ticks)
 {
     STK_ASSERT(host != nullptr);
-    STK_ASSERT(timer != nullptr);
+    STK_ASSERT(tmr != nullptr);
 
-    return host->handle.SetPeriod(timer->handle, period);
+    return host->handle.SetPeriod(tmr->handle, period_ticks);
 }
 
 // -----------------------------------------------------------------------------
 // Timer query
 // -----------------------------------------------------------------------------
 
-bool stk_timer_is_active(const stk_timer_t *timer)
+bool stk_timer_is_active(const stk_timer_t *tmr)
 {
-    STK_ASSERT(timer != nullptr);
+    STK_ASSERT(tmr != nullptr);
 
-    return timer->handle.IsActive();
+    return tmr->handle.IsActive();
 }
 
-uint32_t stk_timer_get_period(const stk_timer_t *timer)
+uint32_t stk_timer_get_period(const stk_timer_t *tmr)
 {
-    STK_ASSERT(timer != nullptr);
+    STK_ASSERT(tmr != nullptr);
 
-    return timer->handle.GetPeriod();
+    return tmr->handle.GetPeriod();
 }
 
-int64_t stk_timer_get_deadline(const stk_timer_t *timer)
+int64_t stk_timer_get_deadline(const stk_timer_t *tmr)
 {
-    STK_ASSERT(timer != nullptr);
+    STK_ASSERT(tmr != nullptr);
 
-    return (int64_t)timer->handle.GetDeadline();
+    return static_cast<int64_t>(tmr->handle.GetDeadline());
 }
 
-int64_t stk_timer_get_timestamp(const stk_timer_t *timer)
+int64_t stk_timer_get_timestamp(const stk_timer_t *tmr)
 {
-    STK_ASSERT(timer != nullptr);
+    STK_ASSERT(tmr != nullptr);
 
-    return (int64_t)timer->handle.GetTimestamp();
+    return static_cast<int64_t>(tmr->handle.GetTimestamp());
 }
 
-uint32_t stk_timer_get_remaining_ticks(const stk_timer_t *timer)
+uint32_t stk_timer_get_remaining_ticks(const stk_timer_t *tmr)
 {
-    STK_ASSERT(timer != nullptr);
+    STK_ASSERT(tmr != nullptr);
 
-    return timer->handle.GetRemainingTicks();
+    return tmr->handle.GetRemainingTicks();
 }
 
 // -----------------------------------------------------------------------------
@@ -331,23 +359,29 @@ struct stk_periodic_trigger_t
     time::PeriodicTrigger handle;
 };
 
-stk_periodic_trigger_t *stk_periodic_trigger_create(stk_periodic_trigger_mem_t *memory,
-                                                    uint32_t                    memory_size,
-                                                    uint32_t                    period,
+stk_periodic_trigger_t *stk_periodic_trigger_create(stk_periodic_trigger_mem_t *const membuf,
+                                                    uint32_t                    membuf_size,
+                                                    uint32_t                    period_ticks,
                                                     bool                        started)
 {
-    STK_ASSERT(memory != nullptr);
-    STK_ASSERT(memory_size >= sizeof(stk_periodic_trigger_t));
-    if (memory == nullptr || memory_size < sizeof(stk_periodic_trigger_t))
-        return nullptr;
+    STK_ASSERT(membuf != nullptr);
+    STK_ASSERT(membuf_size >= sizeof(stk_periodic_trigger_t));
 
-    return new (memory->data) stk_periodic_trigger_t(static_cast<Ticks>(period), started);
+    stk_periodic_trigger_t *result = nullptr;
+    if (membuf_size >= sizeof(stk_periodic_trigger_t))
+    {      
+        result = new (membuf->data) stk_periodic_trigger_t(period_ticks, started);
+    }
+
+    return result;
 }
 
-void stk_periodic_trigger_destroy(stk_periodic_trigger_t *trig)
+void stk_periodic_trigger_destroy(stk_periodic_trigger_t *const trig)
 {
     if (trig != nullptr)
+    {
         trig->~stk_periodic_trigger_t();
+    }
 }
 
 bool stk_periodic_trigger_poll(stk_periodic_trigger_t *trig)
@@ -357,11 +391,11 @@ bool stk_periodic_trigger_poll(stk_periodic_trigger_t *trig)
     return trig->handle.Poll();
 }
 
-void stk_periodic_trigger_set_period(stk_periodic_trigger_t *trig, uint32_t period)
+void stk_periodic_trigger_set_period(stk_periodic_trigger_t *trig, uint32_t period_ticks)
 {
     STK_ASSERT(trig != nullptr);
 
-    trig->handle.SetPeriod(static_cast<Ticks>(period));
+    trig->handle.SetPeriod(period_ticks);
 }
 
 void stk_periodic_trigger_restart(stk_periodic_trigger_t *trig)

--- a/stk/include/arch/stk_arch_common.h
+++ b/stk/include/arch/stk_arch_common.h
@@ -66,7 +66,7 @@ public:
             stack[i] = STK_STACK_MEMORY_FILLER;
         }
         
-        // get address of the last valid item and step forward by 1 Word size
+        // get address of the last valid item and step forward by 1 Word size to point to the top
         const Word stack_top = hw::PtrToWord(memory->GetStack()) + (stack.GetSize() * sizeof(Word));
 
         // expecting STK_STACK_MEMORY_ALIGN-byte aligned memory for a stack

--- a/stk/include/memory/stk_memory_allocator.h
+++ b/stk/include/memory/stk_memory_allocator.h
@@ -204,7 +204,7 @@ struct MemoryAllocator
         \param[in] count: Number of elements (must match the count passed to AllocateT()).
     */
     template <typename TElement>
-    static inline void FreeArrayT(TElement *ptr, size_t count)
+    static inline void FreeArrayT(TElement ptr[], size_t count)
     {
         STK_ASSERT(hw::PtrToWord(&Free) != 0U);
 

--- a/stk/include/memory/stk_memory_blockpool.h
+++ b/stk/include/memory/stk_memory_blockpool.h
@@ -312,7 +312,7 @@ private:
     void *PopFreeList();
 
     uint8_t                 *m_storage;        //!< flat byte array holding all N blocks (owned or external)
-    MemoryBlock             *m_free_list;       //!< head of the intrusive free-list (nullptr when pool is empty)
+    MemoryBlock             *m_free_list;      //!< head of the intrusive free-list (nullptr when pool is empty)
     sync::ConditionVariable  m_cv;             //!< signalled by Free() to wake one task blocked in TimedAlloc()
     size_t                   m_block_size;     //!< aligned block size in bytes (>= BLOCK_ALIGN)
     size_t                   m_capacity;       //!< total number of blocks
@@ -548,7 +548,7 @@ inline void BlockMemoryPool::BuildFreeList()
     // (lowest address), giving ascending allocation order.
     for (size_t i = m_capacity; i-- > 0U; )
     {
-        MemoryBlock *const blk = reinterpret_cast<MemoryBlock *>(m_storage + (i * m_block_size));
+        MemoryBlock *const blk = hw::WordToPtr<MemoryBlock>(hw::PtrToWord(m_storage) + (i * m_block_size));
 
         blk->next   = m_free_list;
         m_free_list = blk;

--- a/stk/include/stk.h
+++ b/stk/include/stk.h
@@ -1615,7 +1615,7 @@ protected:
             else
             if (m_fsm_state == FSM_STATE_SLEEPING)
             {
-                m_task_now = static_cast<KernelTask *>(m_strategy.GetFirst());
+                m_task_now = util::DListCast::ListEntryToParent<KernelTask>(m_strategy.GetFirst());
                 active     = &m_sleep_trap[0].stack;
             }
             else
@@ -1737,7 +1737,8 @@ protected:
 
             if (delta > 0)
             {
-                task->ScheduleSleep(static_cast<Timeout>(Min(delta, static_cast<Ticks>(WAIT_INFINITE))));
+                const Ticks infinite_ticks = WAIT_INFINITE;              
+                task->ScheduleSleep(static_cast<Timeout>(Min(delta, infinite_ticks)));
             }
             else
             {
@@ -2024,7 +2025,7 @@ protected:
         {
             ISyncObject::ListEntryType *const next = itr->GetNext();
 
-            if (!static_cast<ISyncObject *>(itr)->Tick(elapsed_ticks))
+            if (!util::DListCast::ListEntryToParent<ISyncObject>(itr)->Tick(elapsed_ticks))
             {
                 m_sync_list->Unlink(itr);
             }
@@ -2072,7 +2073,7 @@ protected:
         EFsmEvent type = FSM_EVENT_SLEEP;
 
         // try getting next task for scheduling
-        next = static_cast<KernelTask *>(m_strategy.GetNext());
+        next = util::DListCast::ListEntryToParent<KernelTask>(m_strategy.GetNext());
 
         // sleep-aware strategy returns nullptr if no active tasks available
         if (next != nullptr)
@@ -2256,7 +2257,7 @@ protected:
         idle   = now->GetUserStackPtr();
         active = &m_sleep_trap[0].stack;
 
-        m_task_now = static_cast<KernelTask *>(m_strategy.GetFirst());
+        m_task_now = util::DListCast::ListEntryToParent<KernelTask>(m_strategy.GetFirst());
 
     #if STK_SEGGER_SYSVIEW
         SEGGER_SYSVIEW_OnTaskStopReady(now->GetUserStackPtr()->tid, TRACE_EVENT_SLEEP);

--- a/stk/include/stk_arch.h
+++ b/stk/include/stk_arch.h
@@ -32,16 +32,16 @@
 // _STK_ARCH_DEFINED is set by whichever back-end is included; it can be tested by downstream
 // headers or build checks to verify that a valid architecture was selected.
 #ifdef _STK_ARCH_ARM_CORTEX_M
-#include "arch/arm/cortex-m/stk_arch_arm-cortex-m.h"
-#define _STK_ARCH_DEFINED
+    #include "arch/arm/cortex-m/stk_arch_arm-cortex-m.h"
+    #define _STK_ARCH_DEFINED
 #endif
 #ifdef _STK_ARCH_RISC_V
-#include "arch/risc-v/stk_arch_risc-v.h"
-#define _STK_ARCH_DEFINED
+    #include "arch/risc-v/stk_arch_risc-v.h"
+    #define _STK_ARCH_DEFINED
 #endif
 #ifdef _STK_ARCH_X86_WIN32
-#include "arch/x86/win32/stk_arch_x86-win32.h"
-#define _STK_ARCH_DEFINED
+    #include "arch/x86/win32/stk_arch_x86-win32.h"
+    #define _STK_ARCH_DEFINED
 #endif
 
 #ifndef STK_PANIC_HANDLER
@@ -376,10 +376,12 @@ protected:
     \see       WriteVolatile64
 */
 template <typename T>
-__stk_forceinline T ReadVolatile64(volatile const T *addr)
+static __stk_forceinline T ReadVolatile64(volatile const T *addr)
 {
     STK_STATIC_ASSERT_N(sz, sizeof(T) == 8U);  // only 64-bit types permitted
     STK_STATIC_ASSERT_N(al, alignof(T) >= 4U); // type must be at least 4-byte aligned
+    STK_STATIC_ASSERT_N(ilo, ((STK_ENDIAN_IDX_LO >= 0U) && (STK_ENDIAN_IDX_LO <= 1U)));
+    STK_STATIC_ASSERT_N(ihi, ((STK_ENDIAN_IDX_HI >= 0U) && (STK_ENDIAN_IDX_HI <= 1U)));
 
     if __stk_constexpr_cpp17 (sizeof(void *) == 8U) // 64-bit arch: aligned 64-bit load is inherently atomic
     {
@@ -387,12 +389,18 @@ __stk_forceinline T ReadVolatile64(volatile const T *addr)
     }
     else
     {
-        // 32-bit arch: split the 64-bit address into two 32-bit halves.
-        // Writer always updates hi before lo (see WriteVolatile64), so if hi is
-        // the same before and after reading lo, no write straddled the two reads.        
+        // 32-bit arch: split the 64-bit address into two 32-bit halves;
+        // writer always updates hi before lo (see WriteVolatile64), so if hi is
+        // the same before and after reading lo, no write straddled the two reads.
+    #if STK_STRICT_COMPLIANCY
+        const Word p_base = hw::PtrToWord(addr);
+        volatile const uint32_t *const plo = hw::WordToPtr<uint32_t>(p_base + (STK_ENDIAN_IDX_LO * sizeof(uint32_t)));
+        volatile const uint32_t *const phi = hw::WordToPtr<uint32_t>(p_base + (STK_ENDIAN_IDX_HI * sizeof(uint32_t)));
+    #else
         volatile const uint32_t *const p_base = reinterpret_cast<volatile const uint32_t *>(addr);
         volatile const uint32_t *const plo = &p_base[STK_ENDIAN_IDX_LO];
-        volatile const uint32_t *const phi = &p_base[STK_ENDIAN_IDX_HI];
+        volatile const uint32_t *const phi = &p_base[STK_ENDIAN_IDX_HI];  
+    #endif
 
         uint32_t hi, lo;
         do
@@ -405,7 +413,9 @@ __stk_forceinline T ReadVolatile64(volatile const T *addr)
         }
         while (hi != (*phi)); // hi changed: a write occurred during the read; retry
 
-        return (static_cast<uint64_t>(hi) << 32) | lo;
+        const uint64_t result = (static_cast<uint64_t>(hi) << 32U) | static_cast<uint64_t>(lo);
+        
+        return static_cast<T>(result);
     }
 }
 
@@ -431,10 +441,12 @@ __stk_forceinline T ReadVolatile64(volatile const T *addr)
     \see       ReadVolatile64
 */
 template <typename T>
-__stk_forceinline void WriteVolatile64(volatile T *addr, T value)
+static __stk_forceinline void WriteVolatile64(volatile T *addr, T value)
 {
     STK_STATIC_ASSERT_N(sz, sizeof(T) == 8U);  // only 64-bit types permitted
     STK_STATIC_ASSERT_N(al, alignof(T) >= 4U); // type must be at least 4-byte aligned
+    STK_STATIC_ASSERT_N(ilo, ((STK_ENDIAN_IDX_LO >= 0U) && (STK_ENDIAN_IDX_LO <= 1U)));
+    STK_STATIC_ASSERT_N(ihi, ((STK_ENDIAN_IDX_HI >= 0U) && (STK_ENDIAN_IDX_HI <= 1U)));
 
     if __stk_constexpr_cpp17 (sizeof(void *) == 8U) // 64-bit arch: aligned 64-bit store is inherently atomic
     {
@@ -442,13 +454,19 @@ __stk_forceinline void WriteVolatile64(volatile T *addr, T value)
     }
     else
     {
+    #if STK_STRICT_COMPLIANCY
+        const Word p_base = hw::PtrToWord(addr);
+        volatile uint32_t *const plo = hw::WordToPtr<uint32_t>(p_base + (STK_ENDIAN_IDX_LO * sizeof(uint32_t)));
+        volatile uint32_t *const phi = hw::WordToPtr<uint32_t>(p_base + (STK_ENDIAN_IDX_HI * sizeof(uint32_t)));
+    #else
         volatile uint32_t *const p_base = reinterpret_cast<volatile uint32_t *>(addr);
         volatile uint32_t *const plo = &p_base[STK_ENDIAN_IDX_LO];
         volatile uint32_t *const phi = &p_base[STK_ENDIAN_IDX_HI];
+    #endif
 
-        // Write hi first: ReadVolatile64 reads hi twice and retries if it changed,
+        // write hi first: ReadVolatile64 reads hi twice and retries if it changed,
         // so writing hi before lo ensures readers can detect a torn write.
-        (*phi) = static_cast<uint32_t>(static_cast<uint64_t>(value) >> 32);
+        (*phi) = static_cast<uint32_t>(static_cast<uint64_t>(value) >> 32U);
         __stk_full_memfence();
 
         (*plo) = static_cast<uint32_t>(value);
@@ -476,11 +494,20 @@ struct HiResClock
         \note   ISR-safe.
         \return Microseconds.
     */
-    static inline Ticks GetTimeUs()
+    static __stk_forceinline Ticks GetTimeUs()
     {
+        Ticks ticks = 0LL;
         const uint32_t freq = GetFrequency();
-        return ((freq != 0U) ? 
-            static_cast<Ticks>((GetCycles() * 1000000ULL) / freq) : static_cast<Ticks>(0));
+
+        if (freq != 0U)
+        {
+            const Cycles cycles = GetCycles();
+            const Cycles ticksu = (cycles * 1000000ULL) / static_cast<Cycles>(freq);
+            
+            ticks = static_cast<Ticks>(ticksu);
+        }
+
+        return ticks;
     }
 };
 
@@ -504,7 +531,7 @@ static constexpr ITask *GetUserTaskFromTid(TId task_id) noexcept { return hw::Wo
     \note      Can be overridden by defining _STK_CUSTOM_MEMCPY in system configuration.
 */
 #ifndef _STK_CUSTOM_MEMCPY
-static inline void STK_MEMCPY(void *const dest, const void *const src, const size_t size)
+static __stk_forceinline void STK_MEMCPY(void *const dest, const void *const src, const size_t size)
 {
     using namespace stk;
 
@@ -514,6 +541,7 @@ static inline void STK_MEMCPY(void *const dest, const void *const src, const siz
         const Word src_addr  = hw::PtrToWord(src);
 
         // fast path: check if destination, source, and size are all 4-byte aligned
+        // then copy data in 4-byte chunks
         if (((dest_addr & 0x03U) == 0U) && 
             ((src_addr  & 0x03U) == 0U) && 
             ((size      & 0x03U) == 0U))
@@ -522,10 +550,7 @@ static inline void STK_MEMCPY(void *const dest, const void *const src, const siz
             const uint32_t *const p_s32 = static_cast<const uint32_t *>(src);
             const size_t          words = (size >> 2U);
 
-            for (size_t i = 0U; i < words; ++i)
-            {
-                p_d32[i] = p_s32[i];
-            }
+            STK_UNUSED(std::copy_n(p_s32, words, p_d32));
         }
         // slow path
         else

--- a/stk/include/stk_common.h
+++ b/stk/include/stk_common.h
@@ -510,10 +510,10 @@ protected:
         \note      Must be called inside the critical section (see \a hw::CriticalSection, \a sync::ScopedCrticalSection).
     */
     void WakeOne()
-    {
-        if (!m_wait_list.IsEmpty())
+    {      
+        if (IWaitObject *const obj = util::DListCast::ListEntryToParent<IWaitObject>(m_wait_list.GetFirst()))
         {
-            static_cast<IWaitObject *>(m_wait_list.GetFirst())->Wake(false);
+            obj->Wake(false);
         }
     }
 
@@ -525,9 +525,9 @@ protected:
     */
     void WakeAll()
     {
-        while (!m_wait_list.IsEmpty())
+        while (IWaitObject *const obj = util::DListCast::ListEntryToParent<IWaitObject>(m_wait_list.GetFirst()))
         {
-            static_cast<IWaitObject *>(m_wait_list.GetFirst())->Wake(false);
+            obj->Wake(false);
         }
     }
 
@@ -1040,8 +1040,8 @@ public:
     /*! \brief     Get first task.
         \return    Pointer to the first task in the managed set, or \c NULL if no tasks have been added.
     */
-    virtual IKernelTask *GetFirst() const = 0;
-
+    virtual IKernelTask *GetFirst() = 0;
+    
     /*! \brief     Advance the internal iterator and return the next runnable task.
         \return    Pointer to the next active task to schedule, or \c NULL if no runnable tasks are available
                    (in which case the kernel transitions to \a FSM_STATE_SLEEPING).

--- a/stk/include/stk_defs.h
+++ b/stk/include/stk_defs.h
@@ -583,11 +583,11 @@ struct STK_ALLOCATE_COUNT
     \see   STK_ENDIAN_IDX_HI, hw::ReadVolatile64, hw::WriteVolatile64
 */
 #if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
-    #define STK_ENDIAN_IDX_HI (0) // big-endian: high word at index 0
-    #define STK_ENDIAN_IDX_LO (1) // big-endian: low word at index 1
+    #define STK_ENDIAN_IDX_HI (0U) // big-endian: high word at index 0
+    #define STK_ENDIAN_IDX_LO (1U) // big-endian: low word at index 1
 #else
-    #define STK_ENDIAN_IDX_HI (1) // little-endian (default): high word at index 1
-    #define STK_ENDIAN_IDX_LO (0) // little-endian (default): low word at index 0
+    #define STK_ENDIAN_IDX_HI (1U) // little-endian (default): high word at index 1
+    #define STK_ENDIAN_IDX_LO (0U) // little-endian (default): low word at index 0
 #endif
 
 /*! \def       STK_NONCOPYABLE_CLASS

--- a/stk/include/stk_helper.h
+++ b/stk/include/stk_helper.h
@@ -193,11 +193,11 @@ inline bool ISyncObject::Tick(Timeout elapsed_ticks)
     hw::CriticalSection::ScopedLock cs_;
 #endif
 
-    IWaitObject *itr = static_cast<IWaitObject *>(m_wait_list.GetFirst());
+    IWaitObject *itr = util::DListCast::ListEntryToParent<IWaitObject>(m_wait_list.GetFirst());
 
     while (itr != nullptr)
     {
-        IWaitObject *const next = static_cast<IWaitObject *>(itr->GetNext());
+        IWaitObject *const next = util::DListCast::ListEntryToParent<IWaitObject>(itr->GetNext());
 
         if (!itr->Tick(elapsed_ticks))
         {
@@ -214,7 +214,7 @@ inline bool ISyncObject::Tick(Timeout elapsed_ticks)
 inline Weight ISyncObject::FindWeightHigherThan(Weight comp) const
 {
     Weight max_weight = NO_WEIGHT;
-    const IWaitObject *itr = static_cast<const IWaitObject *>(m_wait_list.GetFirst());     
+    const IWaitObject *itr = util::DListCast::ListEntryToParent<const IWaitObject>(m_wait_list.GetFirst());     
 
     while (itr != nullptr)
     {
@@ -224,7 +224,7 @@ inline Weight ISyncObject::FindWeightHigherThan(Weight comp) const
             max_weight = w;
         }
             
-        itr = static_cast<const IWaitObject *>(itr->GetNext());
+        itr = util::DListCast::ListEntryToParent<const IWaitObject>(itr->GetNext());
     }
 
     return ((max_weight > comp) ? max_weight : NO_WEIGHT);
@@ -240,9 +240,19 @@ inline TId ITask::GetId() const
     \return    Id of the calling task/thread.
     \warning   ISR-unsafe. Calling from an ISR context is not permitted and will trigger an assertion.
 */
-__stk_forceinline TId GetTid()
+static __stk_forceinline TId GetTid()
 {
     return IKernelService::GetInstance()->GetTid();
+}
+
+/*! \brief     Get number of microseconds in one tick.
+    \note      Tick is a periodicity of the system timer expressed in microseconds.
+    \note      ISR-safe.
+    \return    Microseconds in one tick.
+*/
+static __stk_forceinline uint32_t GetTickResolution()
+{
+    return IKernelService::GetInstance()->GetTickResolution();
 }
 
 /*! \brief     Convert ticks to milliseconds.
@@ -251,7 +261,7 @@ __stk_forceinline TId GetTid()
     \return    Equivalent time in milliseconds.
     \note      ISR-safe (performs only arithmetic, no kernel calls).
 */
-__stk_forceinline Time GetMsFromTicks(Ticks tick_count, uint32_t resolution)
+static __stk_forceinline Time GetMsFromTicks(Ticks tick_count, uint32_t resolution)
 {
     return static_cast<Time>((tick_count * static_cast<Time>(resolution)) / 1000LL);
 }
@@ -262,28 +272,16 @@ __stk_forceinline Time GetMsFromTicks(Ticks tick_count, uint32_t resolution)
     \return    Equivalent tick count.
     \note      ISR-safe (performs only arithmetic, no kernel calls).
 */
-__stk_forceinline Ticks GetTicksFromMs(Time ms, uint32_t resolution)
+static __stk_forceinline Ticks GetTicksFromMs(Time ms, uint32_t resolution)
 {
-    return static_cast<Ticks>(((resolution != 0U) ? (ms * 1000LL / static_cast<Time>(resolution)) : 0LL));
-}
+    Ticks tick_count = 0LL;
 
-/*! \brief     Get number of ticks elapsed since kernel start.
-    \note      ISR-safe.
-    \return    Ticks.
-*/
-__stk_forceinline Ticks GetTicks()
-{
-    return IKernelService::GetInstance()->GetTicks();
-}
+    if (resolution != 0U)
+    {
+        tick_count = static_cast<Ticks>((ms * 1000LL) / static_cast<Time>(resolution));
+    }
 
-/*! \brief     Get number of microseconds in one tick.
-    \note      Tick is a periodicity of the system timer expressed in microseconds.
-    \note      ISR-safe.
-    \return    Microseconds in one tick.
-*/
-__stk_forceinline uint32_t GetTickResolution()
-{
-    return IKernelService::GetInstance()->GetTickResolution();
+    return tick_count;
 }
 
 /*! \brief     Convert milliseconds to ticks using the current kernel tick resolution.
@@ -293,9 +291,34 @@ __stk_forceinline uint32_t GetTickResolution()
                Use the two-argument form GetTicksFromMsec(ms, resolution) in ISR context.
     \warning   ISR-unsafe (internally calls GetTickResolution() which accesses the kernel service).
 */
-__stk_forceinline Ticks GetTicksFromMs(Time ms)
+static __stk_forceinline Ticks GetTicksFromMs(Time ms)
 {
     return GetTicksFromMs(ms, GetTickResolution());
+}
+
+/*! \brief     Convert milliseconds to ticks and clamp the result to a Timeout type.
+    \param[in] ms: Time in milliseconds to convert.
+    \return    Equivalent tick count clamped to the maximum value allowed by Timeout (WAIT_INFINITE).
+    \note      ISR-unsafe (internally calls GetTickResolution() which accesses the kernel service).
+*/
+static __stk_forceinline Timeout GetTicksFromMsClampedToTimeout(Timeout ms)
+{
+    const Time time_ms = static_cast<Time>(ms);
+    const Ticks tick_count = GetTicksFromMs(time_ms);    
+    
+    const Ticks final_ticks = (tick_count < static_cast<Ticks>(WAIT_INFINITE)) ? 
+        tick_count : static_cast<Ticks>(WAIT_INFINITE);
+        
+    return static_cast<Timeout>(final_ticks);
+}
+
+/*! \brief     Get number of ticks elapsed since kernel start.
+    \note      ISR-safe.
+    \return    Ticks.
+*/
+static __stk_forceinline Ticks GetTicks()
+{
+    return IKernelService::GetInstance()->GetTicks();
 }
 
 /*! \brief     Get current time in milliseconds since kernel start.
@@ -304,21 +327,21 @@ __stk_forceinline Ticks GetTicksFromMs(Time ms)
     \note      When the tick resolution is exactly 1000 µs (1 ms, the default PERIODICITY_DEFAULT),
                the tick count is returned directly without multiplication, avoiding a 64-bit multiply.
 */
-static inline Time GetTimeNowMs()
+static __stk_forceinline Time GetTimeNowMs()
 {
     const IKernelService *const service = IKernelService::GetInstance();
     const uint32_t resolution = service->GetTickResolution();
     const Ticks tick_count = service->GetTicks();
 
     return ((resolution == 1000U) ? tick_count : 
-        ((tick_count * static_cast<Ticks>(resolution)) / static_cast<Ticks>(1000)));
+        ((tick_count * static_cast<Ticks>(resolution)) / 1000LL));
 }
 
 /*! \brief     Get system timer count value.
     \note      ISR-safe.
     \return    64-bit count value.
 */
-__stk_forceinline Cycles GetSysTimerCount()
+static __stk_forceinline Cycles GetSysTimerCount()
 {
     return IKernelService::GetInstance()->GetSysTimerCount();
 }
@@ -327,7 +350,7 @@ __stk_forceinline Cycles GetSysTimerCount()
     \note      ISR-safe.
     \return    Frequency (Hz).
 */
-__stk_forceinline uint32_t GetSysTimerFrequency()
+static __stk_forceinline uint32_t GetSysTimerFrequency()
 {
     return IKernelService::GetInstance()->GetSysTimerFrequency();
 }
@@ -338,7 +361,7 @@ __stk_forceinline uint32_t GetSysTimerFrequency()
     \param[in] tick_count: Sleep time (in ticks). 0 does not cause yield, use Yield instead. Negative will cause an assertion.
     \warning   ISR-unsafe. Calling from an ISR context is not permitted and will trigger an assertion.
 */
-__stk_forceinline void Sleep(Timeout tick_count)
+static __stk_forceinline void Sleep(Timeout tick_count)
 {
     IKernelService::GetInstance()->Sleep(tick_count);
 }
@@ -351,10 +374,9 @@ __stk_forceinline void Sleep(Timeout tick_count)
     \param[in] ms: Sleep time (milliseconds). 0 does not cause yield, use Yield instead. Negative will cause an assertion.
     \warning   ISR-unsafe. Calling from an ISR context is not permitted and will trigger an assertion.
 */
-static inline void SleepMs(Timeout ms)
+static __stk_forceinline void SleepMs(Timeout ms)
 {
-    const Ticks tick_count = GetTicksFromMs(static_cast<Time>(ms));
-    Sleep(static_cast<Timeout>(tick_count < WAIT_INFINITE ? tick_count : WAIT_INFINITE));
+    Sleep(GetTicksFromMsClampedToTimeout(ms));
 }
 
 /*! \brief     Put calling process into a sleep state until the specified timestamp.
@@ -364,7 +386,7 @@ static inline void SleepMs(Timeout ms)
     \warning   ISR-unsafe. Calling from an ISR context is not permitted and will trigger an assertion.
     \return    True if sleep succeeded, false otherwise.
 */
-__stk_forceinline bool SleepUntil(Ticks timestamp)
+static __stk_forceinline bool SleepUntil(Ticks timestamp)
 {
     return IKernelService::GetInstance()->SleepUntil(timestamp);
 }
@@ -374,7 +396,7 @@ __stk_forceinline bool SleepUntil(Ticks timestamp)
     \note      No-op if task was not in a sleeping state.
     \note      ISR-safe.
 */
-__stk_forceinline void SleepCancel(TId task_id)
+static __stk_forceinline void SleepCancel(TId task_id)
 {
     IKernelService::GetInstance()->SleepCancel(task_id);
 }
@@ -383,7 +405,7 @@ __stk_forceinline void SleepCancel(TId task_id)
     \note      A cooperative scheduling mechanism. In HRT mode acts as a cooperation point (see stk::KERNEL_HRT).
     \warning   ISR-unsafe. Calling from an ISR context is not permitted and will trigger an assertion.
 */
-__stk_forceinline void Yield()
+static __stk_forceinline void Yield()
 {
     IKernelService::GetInstance()->SwitchToNext();
 }
@@ -394,7 +416,7 @@ __stk_forceinline void Yield()
     \param[in] tick_count: Delay time (in ticks). Negative will cause an assertion.
     \warning   ISR-unsafe. Calling from an ISR context is not permitted and will trigger an assertion.
 */
-__stk_forceinline void Delay(Timeout tick_count)
+static __stk_forceinline void Delay(Timeout tick_count)
 {
     IKernelService::GetInstance()->Delay(tick_count);
 }
@@ -405,10 +427,9 @@ __stk_forceinline void Delay(Timeout tick_count)
     \param[in] ms: Delay time (milliseconds). Negative will cause an assertion.
     \warning   ISR-unsafe. Calling from an ISR context is not permitted and will trigger an assertion.
 */
-static inline void DelayMs(Timeout ms)
+static __stk_forceinline void DelayMs(Timeout ms)
 {
-    const Ticks tick_count = GetTicksFromMs(static_cast<Time>(ms));
-    Delay(static_cast<Timeout>(tick_count < WAIT_INFINITE ? tick_count : WAIT_INFINITE));
+    Delay(GetTicksFromMsClampedToTimeout(ms));
 }
 
 } // namespace stk

--- a/stk/include/stk_linked_list.h
+++ b/stk/include/stk_linked_list.h
@@ -63,6 +63,11 @@ public:
     */
     explicit DListEntry() : m_head(nullptr), m_next(nullptr), m_prev(nullptr)
     {}
+    
+    /*! \brief A tag for type-safe casts done by CastListEntryToParent.
+        \see   CastListEntryToParent.
+    */
+    enum { DLEntryTag = 1 };
 
     /*! \typedef DLEntryType
         \brief   Convenience alias for this entry type. Used to avoid repeating the full template spelling.
@@ -445,6 +450,25 @@ private:
     size_t       m_count; //!< Number of entries currently in the list.
     DLEntryType *m_first; //!< Pointer to the first (front) entry, or \c NULL when empty.
     DLEntryType *m_last;  //!< Pointer to the last (back) entry, or \c NULL when empty.
+};
+
+/*! \class DListCast
+    \brief Helper for casting list entries to concrete (parent) types.
+*/
+struct DListCast
+{
+    /*! \brief     Safely casts an intrusive list entry to its concrete parent container object type.
+        \param[in] entry: Pointer to the intrusive list entry. Must be a valid pointer or \c nullptr.
+        \return    A pointer converted to the target parent container type \c TargetType, or \c nullptr if the input entry was \c nullptr.
+    */
+    template <typename TTargetType, typename TSourceType>
+    static __stk_forceinline TTargetType *ListEntryToParent(TSourceType *const node)
+    {
+        STK_STATIC_ASSERT_N(TT, TTargetType::DLEntryTag == 1); // TTargetType must inherit DLEntryType
+        STK_STATIC_ASSERT_N(ST, TSourceType::DLEntryTag == 1); // TSourceType must inherit DLEntryType
+      
+        return static_cast<TTargetType *>(node);
+    }
 };
 
 } // namespace util

--- a/stk/include/strategy/stk_strategy_edf.h
+++ b/stk/include/strategy/stk_strategy_edf.h
@@ -168,13 +168,11 @@ public:
                    at kernel start to seed the initial context; EDF ordering begins with the
                    first GetNext() call.
     */
-    IKernelTask *GetFirst() const override
+    IKernelTask *GetFirst() override
     {
         STK_ASSERT(GetSize() != 0U);
-
-        return (!m_tasks.IsEmpty() ?
-            (*const_cast<IKernelTask::ListEntryType *>(m_tasks.GetFirst())) :
-            (*const_cast<IKernelTask::ListEntryType *>(m_sleep.GetFirst())));
+        
+        return (*(!m_tasks.IsEmpty() ? m_tasks.GetFirst() : m_sleep.GetFirst()));
     }
 
     /*! \brief  Get total number of tasks managed by this strategy.

--- a/stk/include/strategy/stk_strategy_fpriority.h
+++ b/stk/include/strategy/stk_strategy_fpriority.h
@@ -188,7 +188,7 @@ public:
                    with GetNext(). The sleep fallback allows the kernel to identify any task even
                    when all are currently sleeping.
     */
-    IKernelTask *GetFirst() const override
+    IKernelTask *GetFirst() override
     {
         STK_ASSERT(GetSize() != 0U);
 
@@ -196,12 +196,12 @@ public:
 
         if (m_ready_bitmap == 0U)
         {
-            first_task = (*const_cast<IKernelTask::ListEntryType *>(m_sleep.GetFirst()));
+            first_task = (*m_sleep.GetFirst());
         }
         else
         {
             const Priority prio = GetHighestReadyPriority(m_ready_bitmap);
-            first_task = (*const_cast<IKernelTask::ListEntryType *>(m_tasks[prio].GetFirst()));
+            first_task = (*m_tasks[prio].GetFirst());
         }
 
         return first_task;

--- a/stk/include/strategy/stk_strategy_monotonic.h
+++ b/stk/include/strategy/stk_strategy_monotonic.h
@@ -217,11 +217,11 @@ public:
                    returned task may be sleeping; the kernel uses it only to seed the initial
                    context before the first GetNext() call.
     */
-    IKernelTask *GetFirst() const override
+    IKernelTask *GetFirst() override
     {
         STK_ASSERT(m_tasks.GetSize() != 0U);
 
-        return (*const_cast<IKernelTask::ListEntryType *>(m_tasks.GetFirst()));
+        return (*m_tasks.GetFirst());
     }
 
     /*! \brief     Get the total number of tasks managed by this strategy.
@@ -354,9 +354,9 @@ public:
     static inline SchedulabilityCheckResult<TTaskCount> IsSchedulableWCRT(const ITaskSwitchStrategy *strategy)
     {
         STK_ASSERT(strategy != nullptr);
-        STK_ASSERT(strategy->GetFirst() != nullptr);
+        STK_ASSERT(const_cast<ITaskSwitchStrategy *>(strategy)->GetFirst() != nullptr);
 
-        const IKernelTask::ListHeadType *const ktasks = strategy->GetFirst()->GetHead();
+        const IKernelTask::ListHeadType *const ktasks = const_cast<ITaskSwitchStrategy *>(strategy)->GetFirst()->GetHead();
 
         STK_ASSERT(ktasks != nullptr);
         STK_ASSERT(ktasks->GetSize() <= TTaskCount);
@@ -370,13 +370,15 @@ public:
         do
         {
             STK_ASSERT(idx < TTaskCount);
+            
             tasks[idx].period   = static_cast<uint32_t>(itr->GetHrtPeriodicity());
             tasks[idx].duration = static_cast<uint32_t>(itr->GetHrtDeadline());
-            idx += 1U;
+            ++idx;
             
             itr = (*itr->GetNext());
         }
         while (itr != start);
+        
         STK_ASSERT(idx == TTaskCount);
 
         // calculate CPU load
@@ -420,16 +422,14 @@ public:
                    computed WCRT for task \e i on return.
        \return     \c true if every task's WCRT <= its period (Tx); \c false if any task misses.
      */
-    static inline bool CalculateWCRT(const TaskTiming *task_array, const uint32_t count, TaskInfo *info_array)
+    static inline bool CalculateWCRT(const TaskTiming tasks[], const uint32_t count, TaskInfo info[])
     {
         bool schedulable = true;
-        ArrayView<const TaskTiming> tasks(task_array, count);
-        ArrayView<TaskInfo> info(info_array, count);
         info[0].wcrt = tasks[0].duration;
 
-        for (uint32_t t = 1U; t < tasks.GetSize(); )
+        for (uint32_t t = 1U; t < count; )
         {
-            uint32_t       w  = 0U;
+            uint32_t       w;
             const uint32_t Cx = tasks[t].duration;
             const uint32_t Tx = tasks[t].period;
             uint32_t       w0 = Cx;
@@ -465,7 +465,7 @@ public:
                     computed with integer arithmetic (truncating division). Cumulative load
                     is the running sum from index 0 to \a count - 1.
     */
-    static inline void GetTaskCpuLoad(const TaskTiming *tasks, const uint32_t count, TaskInfo *info)
+    static inline void GetTaskCpuLoad(const TaskTiming tasks[], const uint32_t count, TaskInfo info[])
     {
         uint16_t total = 0U;
 

--- a/stk/include/strategy/stk_strategy_rrobin.h
+++ b/stk/include/strategy/stk_strategy_rrobin.h
@@ -135,13 +135,11 @@ public:
         \note      Preference is given to runnable tasks. The sleep fallback allows the kernel to
                    identify any task even when all are currently sleeping.
     */
-    IKernelTask *GetFirst() const override
+    IKernelTask *GetFirst() override
     {
         STK_ASSERT(GetSize() != 0U);
-
-        return (!m_tasks.IsEmpty() ?
-            (*const_cast<IKernelTask::ListEntryType *>(m_tasks.GetFirst())) :
-            (*const_cast<IKernelTask::ListEntryType *>(m_sleep.GetFirst())));
+        
+        return (*(!m_tasks.IsEmpty() ? m_tasks.GetFirst() : m_sleep.GetFirst()));
     }
 
     /*! \brief  Get total number of tasks managed by this strategy.

--- a/stk/include/strategy/stk_strategy_swrrobin.h
+++ b/stk/include/strategy/stk_strategy_swrrobin.h
@@ -178,13 +178,11 @@ public:
         \note      Preference is given to runnable tasks. The sleep fallback allows the kernel to
                    identify any task even when all are currently sleeping.
     */
-    IKernelTask *GetFirst() const override
+    IKernelTask *GetFirst() override
     {
         STK_ASSERT(GetSize() != 0U);
-
-        return (!m_tasks.IsEmpty() ?
-            (*const_cast<IKernelTask::ListEntryType *>(m_tasks.GetFirst())) :
-            (*const_cast<IKernelTask::ListEntryType *>(m_sleep.GetFirst())));
+        
+        return (*(!m_tasks.IsEmpty() ? m_tasks.GetFirst() : m_sleep.GetFirst()));
     }
 
     /*! \brief  Get the total number of tasks managed by this strategy.

--- a/stk/include/sync/stk_sync_mutex.h
+++ b/stk/include/sync/stk_sync_mutex.h
@@ -209,7 +209,7 @@ inline void Mutex::Unlock()
         if (!m_wait_list.IsEmpty())
         {
             // pass ownership directly to the first waiter (FIFO order)
-            IWaitObject *const waiter = static_cast<IWaitObject *>(m_wait_list.GetFirst());
+            IWaitObject *const waiter = util::DListCast::ListEntryToParent<IWaitObject>(m_wait_list.GetFirst());
 
             // transfer ownership to the waiter
             m_recursion_count = 1U;

--- a/stk/include/time/stk_time_timer.h
+++ b/stk/include/time/stk_time_timer.h
@@ -137,6 +137,7 @@ public:
     class Timer : private util::DListEntry<Timer, false>
     {
         friend class TimerHost;
+        friend class util::DListCast; // allow casts because DListEntry is private
 
     public:
         /*! \brief     Default constructor.
@@ -150,6 +151,11 @@ public:
             \note      MISRA deviation: [STK-DEV-005] Rule 10-3-2.
         */
         STK_VIRT_DTOR ~Timer() = default;
+        
+        /*! \brief A tag for type-safe casts done by CastListEntryToParent.
+            \see   CastListEntryToParent.
+        */
+        enum { DLEntryTag = 1 };
 
         /*! \brief     Callback invoked by the handler task when this timer expires.
             \param[in] host: Pointer to the TimerHost that fired this timer.
@@ -693,10 +699,10 @@ inline void TimerHost::UpdateTime()
         // using WriteVolatile64() to guarantee correct lockless reading order by ReadVolatile64
         hw::WriteVolatile64(&m_now, now);
 
-        Timer *tmr = static_cast<Timer *>(m_active.GetFirst());
+        Timer *tmr = util::DListCast::ListEntryToParent<Timer>(m_active.GetFirst());
         while (tmr != nullptr)
         {
-            Timer *const next = static_cast<Timer *>(tmr->GetNext());
+          Timer *const next = util::DListCast::ListEntryToParent<Timer>(tmr->GetNext());
 
             if (tmr->m_active)
             {

--- a/test/generic/stktest_kernel.cpp
+++ b/test/generic/stktest_kernel.cpp
@@ -127,7 +127,7 @@ TEST(Kernel, AddTask)
 {
     Kernel<KERNEL_STATIC, 1, SwitchStrategyRR, PlatformTestMock> kernel;
     TaskMock<ACCESS_USER> task;
-    const ITaskSwitchStrategy *strategy = kernel.GetSwitchStrategy();
+    ITaskSwitchStrategy *strategy = kernel.GetSwitchStrategy();
     PlatformTestMock *platform = static_cast<PlatformTestMock *>(kernel.GetPlatform());
 
     kernel.Initialize();
@@ -240,7 +240,7 @@ TEST(Kernel, AddTaskWhenStarted)
 {
     Kernel<KERNEL_DYNAMIC, 2, SwitchStrategyRR, PlatformTestMock> kernel;
     TaskMock<ACCESS_USER> task1, task2;
-    const ITaskSwitchStrategy *strategy = kernel.GetSwitchStrategy();
+    ITaskSwitchStrategy *strategy = kernel.GetSwitchStrategy();
 
     kernel.Initialize();
     kernel.AddTask(&task1);
@@ -308,7 +308,7 @@ TEST(Kernel, RemoveTask)
 {
     Kernel<KERNEL_DYNAMIC, 2, SwitchStrategyRR, PlatformTestMock> kernel;
     TaskMock<ACCESS_USER> task1, task2;
-    const ITaskSwitchStrategy *strategy = kernel.GetSwitchStrategy();
+    ITaskSwitchStrategy *strategy = kernel.GetSwitchStrategy();
 
     kernel.Initialize();
     kernel.AddTask(&task1);
@@ -943,7 +943,7 @@ TEST(Kernel, HrtApiForNonHrtTask)
 {
     Kernel<KERNEL_STATIC, 1, SwitchStrategyRR, PlatformTestMock> kernel;
     TaskMock<ACCESS_USER> task;
-    const ITaskSwitchStrategy *strategy = kernel.GetSwitchStrategy();
+    ITaskSwitchStrategy *strategy = kernel.GetSwitchStrategy();
 
     kernel.Initialize();
     kernel.AddTask(&task);
@@ -1048,7 +1048,7 @@ TEST(Kernel, HrtTaskCompleted)
     Kernel<KERNEL_DYNAMIC | KERNEL_HRT, 1, SwitchStrategyRR, PlatformTestMock> kernel;
     TaskMock<ACCESS_USER> task;
     PlatformTestMock *platform = static_cast<PlatformTestMock *>(kernel.GetPlatform());
-    const ITaskSwitchStrategy *strategy = kernel.GetSwitchStrategy();
+    ITaskSwitchStrategy *strategy = kernel.GetSwitchStrategy();
 
     kernel.Initialize();
     kernel.AddTask(&task, 1, 1, 0);
@@ -1584,7 +1584,7 @@ TEST(Kernel, CheckWeightLessApi)
 {
     Kernel<KERNEL_STATIC, 1, SwitchStrategyRR, PlatformTestMock> kernel;
     TaskMock<ACCESS_USER> task;
-    const ITaskSwitchStrategy *strategy = kernel.GetSwitchStrategy();
+    ITaskSwitchStrategy *strategy = kernel.GetSwitchStrategy();
 
     kernel.Initialize();
     kernel.AddTask(&task);


### PR DESCRIPTION
- ISwitchStrategy::GetFirst() API is changed to non-const to simplify implementation and remove excessive conversion-related warnings. 
- Add util::DListCast helper to cast list entries to derived types safely.