### PR TITLE
Add time::Stopwatch class utility for measurement tasks.

### DIFF
--- a/stk/README.md
+++ b/stk/README.md
@@ -221,10 +221,10 @@ class MyTask : public stk::Task<256, Mode>
 
 | Function                     | ISR-safe  | Description                              |
 |------------------------------|-----------|------------------------------------------|
-| `GetTid()`                   | No        | Task identifier of the calling task      |
+| `GetTid()`                   | Yes       | Task identifier of the calling task      |
 | `GetTicks()`                 | Yes       | Ticks elapsed since kernel start         |
 | `GetTickResolution()`        | Yes       | Microseconds per tick                    |
-| `GetTicksFromMs(ms)`         | No        | Convert ms → ticks (queries resolution)  |
+| `GetTicksFromMs(ms)`         | Yes       | Convert ms → ticks (queries resolution)  |
 | `GetTicksFromMs(ms, res)`    | Yes       | Convert ms → ticks (explicit resolution) |
 | `GetMsFromTicks(ticks, res)` | Yes       | Convert ticks → ms                       |
 | `GetTimeNowMs()`             | Yes       | Milliseconds since kernel start          |
@@ -313,14 +313,18 @@ Defines `PlatformContext` — the base class inherited by every concrete platfor
 
 **Supported cores:**
 
-| Core                 | ISA              | FPU      | DWT  | Privilege  | TrustZone  |
-|----------------------|------------------|----------|------|------------|------------|
-| Cortex-M0 / M0+ / M1 | ARMv6-M          | No       | No   | No         | No         |
-| Cortex-M3            | ARMv7-M          | No       | Yes  | Yes        | No         |
-| Cortex-M4            | ARMv7-M          | Optional | Yes  | Yes        | No         |
-| Cortex-M7            | ARMv7-M          | Optional | Yes  | Yes        | No         |
-| Cortex-M23           | ARMv8-M Baseline | No       | No   | Yes        | Optional   |
-| Cortex-M33           | ARMv8-M Mainline | Optional | Yes  | Yes        | Optional   |
+| Core                 | ISA                | FPU      | DWT  | Privilege  | TrustZone  |
+|----------------------|--------------------|----------|------|------------|------------|
+| Cortex-M0 / M0+ / M1 | ARMv6-M            | No       | No   | No         | No         |
+| Cortex-M3            | ARMv7-M            | No       | Yes  | Yes        | No         |
+| Cortex-M4            | ARMv7-M            | Optional | Yes  | Yes        | No         |
+| Cortex-M7            | ARMv7-M            | Optional | Yes  | Yes        | No         |
+| Cortex-M23           | ARMv8-M Baseline   | No       | No   | Yes        | Optional   |
+| Cortex-M33           | ARMv8-M Mainline   | Optional | Yes  | Yes        | Optional   |
+| Cortex-M35P          | ARMv8-M Mainline   | Optional | Yes  | Yes        | Optional   |
+| Cortex-M52           | ARMv8.1-M Mainline | Optional | Yes  | Yes        | Optional   |
+| Cortex-M55           | ARMv8.1-M Mainline | Optional | Yes  | Yes        | Optional   |
+| Cortex-M85           | ARMv8.1-M Mainline | Optional | Yes  | Yes        | Optional   |
 
 Context switching uses **SysTick** (tick source) → **PendSV** (lowest-priority, deferred context switch) → **SVC** (scheduler start, privileged critical section entry/exit). The core variant is auto-detected from the CMSIS `__CORTEX_M` macro.
 

--- a/stk/include/stk_defs.h
+++ b/stk/include/stk_defs.h
@@ -607,6 +607,26 @@ struct STK_ALLOCATE_COUNT
 */
 #define STK_UNUSED(X) static_cast<void>((X))
 
+/*! \def       STK_LIKELY
+    \brief     Provides a compiler hint that the given expression is highly likely to evaluate to true.
+    \param     x The expression to evaluate.
+*/
+/*! \def       STK_UNLIKELY
+    \brief     Provides a compiler hint that the given expression is highly unlikely to evaluate to true
+               (typically used for error handling).
+    \param     x The expression to evaluate.
+*/
+#if __cplusplus >= 202002L
+    #define STK_LIKELY(x)   ([]() { if constexpr (!!(x)) [[likely]] return true; else return false; }())
+    #define STK_UNLIKELY(x) ([]() { if constexpr (!!(x)) return true; else [[unlikely]] return false; }())
+#elif defined(__GNUC__) || defined(__clang__)
+    #define STK_LIKELY(x)   __builtin_expect(!!(x), 1)
+    #define STK_UNLIKELY(x) __builtin_expect(!!(x), 0)
+#else
+    #define STK_LIKELY(x)   (x)
+    #define STK_UNLIKELY(x) (x)
+#endif
+
 /*! \namespace stk
     \brief     Namespace of STK package.
  */

--- a/stk/include/time/README.md
+++ b/stk/include/time/README.md
@@ -1,6 +1,6 @@
 # STK Time Module (`stk::time`)
 
-**STK Time Module** provides lightweight, zero-allocation time utilities for embedded systems. It includes a single-task periodic polling trigger and a full-featured kernel-backed software timer framework capable of managing many independent timers at constant task overhead.
+**STK Time Module** provides lightweight, zero-allocation time utilities for embedded systems. It includes a single-task periodic polling trigger, a full-featured kernel-backed software timer framework capable of managing many independent timers at constant task overhead, and a lightweight stopwatch for measuring elapsed cycles between events.
 
 ## Features
 
@@ -11,6 +11,7 @@
 - **Atomic Operations**: `Restart()` and `StartOrReset()` perform compound state changes atomically with respect to the tick task, eliminating TOCTOU races.
 - **Low-Power Aware**: The tick task sleeps until the nearest deadline; handler tasks block until a timer expires.
 - **ISR Context**: `PeriodicTrigger` is suitable for use inside a single task or ISR. `TimerHost` commands must be issued from task context.
+- **Source-Agnostic Measurement**: `Stopwatch` measures elapsed counter units (e.g. CPU cycles) between calls using a caller-supplied time source, independent of any particular hardware counter.
 
 ---
 
@@ -94,6 +95,26 @@ Each `Timer` instance may be registered with at most one `TimerHost` at a time.
 
 ---
 
+### 4. Stopwatch (`time::Stopwatch`)
+
+A lightweight elapsed-cycle measurement utility. Measures the number of CPU cycles (or other monotonic counter units) elapsed between successive calls to `Update()`. The time source is supplied by the caller as a callable (function pointer, lambda, or functor), so the stopwatch itself is independent of any particular hardware counter.
+
+- **Usage**: Call `Start()` once with a time-source callable to capture the reference point, then call `Update()` (with the same callable) to retrieve elapsed cycles since the last `Start()`/`Update()` call.
+- **Implicit start**: If `Update()` is called before `Start()`, the first call is treated as the start point and returns 0.
+- **Wrap-around safe**: Counter wrap-around is handled naturally via unsigned subtraction, provided elapsed time doesn't exceed one full counter period.
+
+**Key methods:**
+
+| Method | Description |
+|---|---|
+| `Stopwatch()` | Construct in the stopped state. |
+| `Start(now_func)` | Capture the current reference point using the supplied time-source callable. |
+| `Update(now_func)` | Returns elapsed `Cycles` since the last `Start()`/`Update()` call, and updates the reference point. Returns 0 on the first call if `Start()` was not called beforehand. |
+
+> **Note**: Not thread-safe. Intended for use within a single task or ISR context. `now_func` must return a `Cycles` value and should be the same time source across `Start()`/`Update()` calls in a given measurement.
+
+---
+
 ## Usage Examples
 
 ### `PeriodicTrigger` — Polling-based periodic task
@@ -114,6 +135,24 @@ void TaskRun()
             ReadSensor();
         }
     }
+}
+```
+
+### `Stopwatch` — Measuring elapsed cycles
+
+```cpp
+#include <time/stk_time_util.h>
+
+stk::time::Stopwatch sw;
+
+void MeasureWork()
+{
+    sw.Start([]() { return stk::hw::HiResClock::GetCycles(); });
+
+    DoWork();
+
+    stk::Cycles elapsed = sw.Update([]() { return stk::hw::HiResClock::GetCycles(); });
+    LogCycles(elapsed);
 }
 ```
 

--- a/stk/include/time/stk_time_util.h
+++ b/stk/include/time/stk_time_util.h
@@ -126,6 +126,91 @@ protected:
     uint32_t m_period; //!< Trigger period in ticks. Modified only by SetPeriod(). Must be > 0.
 };
 
+/*! \struct Stopwatch
+    \brief  Lightweight elapsed-cycle measurement utility.
+
+    Measures the number of CPU cycles (or other monotonic counter units) that
+    have elapsed between successive calls to Update(). The time source is
+    supplied by the caller as a callable (function pointer, lambda, or functor),
+    allowing the stopwatch to remain independent of any particular hardware
+    counter.
+
+    Typical usage:
+    \code
+    stk::time::Stopwatch sw;
+    sw.Start([]() { return stk::hw::HiResClock::GetCycles(); });
+
+    // ... work to be measured ...
+
+    Cycles elapsed = sw.Update([]() { return stk::hw::HiResClock::GetCycles(); });
+    // elapsed holds the number of cycles since the last Start() or Update().
+    \endcode
+
+    \note  Not thread-safe. Intended for use within a single task or ISR context.
+    \note  If Update() is called before Start(), the first call is treated as a
+           start point and returns 0 cycles elapsed.
+    \note  Wrap-around of the underlying counter is handled naturally by
+           unsigned subtraction, provided the elapsed time does not exceed
+           one full counter period.
+*/
+class Stopwatch
+{
+    static constexpr Cycles NOT_STARTED = 0ULL; //!< Value of m_prev meaning that stopwatch is not started.
+
+public:
+    /*! \brief  Construct a Stopwatch.
+        \note   The stopwatch is initially stopped. Call Start() before the
+                first meaningful Update() call; otherwise the first Update()
+                call will implicitly act as the start point and return 0.
+    */
+    Stopwatch() : m_prev(NOT_STARTED)
+    {}
+
+    /*! \brief     Capture the start time.
+        \tparam    Func: Callable type returning a \c Cycles value.
+        \param[in] now_func: Callable invoked with no arguments that returns
+                   the current time as a \c Cycles value (e.g. a CPU cycle counter
+                   read function or a lambda wrapping one).
+        \note      Resets the internal reference point to the current counter value.
+                   The next Update() call will measure elapsed cycles from this moment.
+    */
+    template <typename Func>
+    void Start(Func now_func)
+    {
+        m_prev = static_cast<Cycles>(now_func());
+    }
+
+    /*! \brief     Return the number of cycles elapsed since the last Start() or Update().
+        \tparam    Func: Callable type returning a \c Cycles value.
+        \param[in] now_func: Callable invoked with no arguments that returns
+                   the current time as a \c Cycles value. Must be the same counter
+                   source used in the preceding Start() call.
+        \return    Elapsed \c Cycles since the previous reference point.
+                   Returns \c 0 on the very first call when Start() was not called
+                   beforehand (the call itself becomes the new reference point).
+        \note      Updates the internal reference point to the current counter value,
+                   so each successive call measures the interval since the previous one.
+    */
+    template <typename Func>
+    Cycles Update(Func now_func)
+    {
+        Cycles now = static_cast<Cycles>(now_func());
+
+        if (STK_UNLIKELY(m_prev == NOT_STARTED))
+        {
+            m_prev = now;
+        }
+
+        Cycles diff = now - m_prev;
+        m_prev = now;
+
+        return diff;
+    }
+
+protected:
+    Cycles m_prev; //!< Counter value captured at the last Start() or Update() call.
+};
+
 } // namespace time
 } // namespace stk
 


### PR DESCRIPTION
Trivial example of new class:

```cpp
#include <time/stk_time_util.h>

stk::time::Stopwatch sw;

void MeasureWork()
{
    sw.Start([]() { return stk::hw::HiResClock::GetCycles(); });

    DoWork();

    stk::Cycles elapsed = sw.Update([]() { return stk::hw::HiResClock::GetCycles(); });
    LogCycles(elapsed);
}
```

It is possible to employ less precise counter, for example if `hw::HiResClock` can't be used due to access/priviledge level:

```cpp
#include <time/stk_time_util.h>

stk::time::Stopwatch sw;

void MeasureWork()
{
    sw.Start([]() { return stk::GetTicks(); });

    DoWork();

    stk::Cycles elapsed = sw.Update([]() { return stk::GetTicks(); });
    LogCycles(elapsed);
}
```

Lambda is fully inlined by the compiler resulting in no overhead.