### PR TITLE
Add support for non-register TLS for RISC-V.

### DIFF
--- a/stk/include/arch/risc-v/stk_arch_risc-v.h
+++ b/stk/include/arch/risc-v/stk_arch_risc-v.h
@@ -69,9 +69,8 @@ public:
 */
 typedef PlatformRiscV PlatformDefault;
 
-// Enforce inline TLS because RISC-V always provides x5/tp register for riscv-none-elf-gcc or similar.
-#undef STK_TLS_PREFER_REGISTER
-#define STK_TLS_PREFER_REGISTER 1
+// Inline TLS via x4/tp. Active when both STK_TLS and STK_TLS_PREFER_REGISTER are enabled.
+#if STK_TLS && STK_TLS_PREFER_REGISTER
 
 /*! \brief  Get thread-local storage (TLS).
     \return TLS value.
@@ -95,6 +94,8 @@ static __stk_forceinline void SetTls(Word tp)
 
 // Notify stk_arch.h that we defined inline versions of GetTls/SetTls.
 #define STK_INLINE_TLS 1
+
+#endif // STK_TLS && STK_TLS_PREFER_REGISTER
 
 } // namespace stk
 

--- a/stk/include/stk_common.h
+++ b/stk/include/stk_common.h
@@ -300,15 +300,13 @@ template <size_t TStackSize> struct StackMemoryDef
 */
 struct Stack
 {
-    Word        SP;          //!< Stack Pointer (SP) register (note: must be the first entry in this struct).
-    uint32_t    access_mode; //!< Bitfield with hardware access mode of the task (see \a EAccessMode).
+    Word        SP;          //!< Stack Pointer (SP) register (note: must be the first entry in this struct). Offset is fixed at 0 bytes, required by the driver.
+    uint32_t    access_mode; //!< Bitfield with hardware access mode of the task (see \a EAccessMode). Offset is fixed at 4 bytes, required by the driver.
+#if STK_TLS && !STK_TLS_PREFER_REGISTER
+    Word        tls;         //!< Thread-local storage if not using ARM Cortex-M R9 register for a fast inline access to TLS.
+#endif
 #if STK_STACK_NEEDS_TASK_ID
     TId         tid;         //!< Task id (see \a STK_SEGGER_SYSVIEW).
-#endif
-#ifdef _STK_ARCH_ARM_CORTEX_M
-#if STK_TLS && !STK_TLS_PREFER_REGISTER
-    Word        tls;        //!< Thread-local storage if not using ARM Cortex-M R9 register for a fast inline access to TLS.
-#endif
 #endif
 };
 

--- a/stk/include/stk_defs.h
+++ b/stk/include/stk_defs.h
@@ -108,9 +108,9 @@
            callee-saved register, silently overwriting the TLS pointer after a
            context switch. See stk_arch_arm-cortex-m.h for the full explanation.
     \note  **RISC-V:** uses the \c tp (x4) register, which is reserved for TLS by
-           the RISC-V psABI. STK_TLS_PREFER_REGISTER is forced to 1 on RISC-V
-           regardless of this setting; no additional compiler flags are needed.
-    \note  When set to 1 on Cortex-M, stk::Stack gains no \c tls member, reducing
+           the RISC-V psABI. STK_TLS_PREFER_REGISTER is set to 1 on RISC-V;
+           no additional compiler flags are needed. Can be overridden to 0 safely.
+    \note  When set to 1 the stk::Stack gains no \c tls member, reducing
            per-task RAM by one \c Word. On targets with many tasks this saving can
            be significant.
     \note  Default: 0 (disabled). Leave at 0 if \c -ffixed-r9 cannot be applied
@@ -124,7 +124,11 @@
     \see   STK_TLS, stk::hw::GetTlsPtr, stk::hw::SetTlsPtr
 */
 #ifndef STK_TLS_PREFER_REGISTER
-    #define STK_TLS_PREFER_REGISTER (0)
+    #ifdef _STK_ARCH_RISC_V
+        #define STK_TLS_PREFER_REGISTER (1)
+    #else
+        #define STK_TLS_PREFER_REGISTER (0)
+    #endif
 #endif
 
 /*! \def   STK_STACK_NEEDS_TASK_ID

--- a/stk/src/arch/risc-v/stk_arch_risc-v.cpp
+++ b/stk/src/arch/risc-v/stk_arch_risc-v.cpp
@@ -1094,6 +1094,26 @@ static struct Context final : public PlatformContext
         }
     }
 
+#if STK_TLS && !STK_INLINE_TLS
+    Word GetTls()
+    {
+        hw::CriticalSection::ScopedLock cs_;
+
+        STK_ASSERT(m_stack_active != nullptr);
+
+        return m_stack_active->tls;
+    }
+
+    void SetTls(Word tp)
+    {
+        hw::CriticalSection::ScopedLock cs_;
+
+        STK_ASSERT(m_stack_active != nullptr);
+
+        m_stack_active->tls = tp;
+    }
+#endif // STK_TLS && !STK_INLINE_TLS
+
     void Start();
     void OnStart();
     void OnStop();
@@ -2150,5 +2170,17 @@ uint32_t stk::hw::HiResClock::GetFrequency()
     STK_ASSERT(freq != 0U);
     return freq;
 }
+
+#if STK_TLS && !STK_INLINE_TLS
+Word stk::hw::GetTls()
+{
+    return GetContext().GetTls();
+}
+
+void stk::hw::SetTls(Word tp)
+{
+    GetContext().SetTls(tp);
+}
+#endif // STK_TLS && !STK_INLINE_TLS
 
 #endif // _STK_ARCH_RISC_V


### PR DESCRIPTION
Non register based TLS is activated by: `STK_TLS=1`, `STK_TLS_PREFER_REGISTER=0`.

By default RISC-V defaults `STK_TLS_PREFER_REGISTER` to 1 as `tp/x4` register is always available, but can be overridden in stk_config.h to 0 to use `Stack::tls` member and free `x4` register for something else.